### PR TITLE
Use variables for redfish credentials in conductor.yml

### DIFF
--- a/environments/manager/files/conductor.yml
+++ b/environments/manager/files/conductor.yml
@@ -2,8 +2,8 @@
 ironic_parameters:
   driver: redfish
   driver_info:
-    redfish_username: admin
-    redfish_password: password
+    redfish_username: "{{ remote_board_username }}"
+    redfish_password: "{{ remote_board_password }}"
     redfish_address: "https://{{ remote_board_address }}"
     redfish_system_id: /redfish/v1/Systems/1
     redfish_verify_ca: False


### PR DESCRIPTION
Replace hardcoded username and password with Ansible variables remote_board_username and remote_board_password for better security.