### PR TITLE
Add ZTP configuration for EdgeCore devices in dnsmasq

### DIFF
--- a/environments/infrastructure/configuration.yml
+++ b/environments/infrastructure/configuration.yml
@@ -6,6 +6,8 @@ dnsmasq_enable_dns: true
 dnsmasq_enable_tftp: false
 dnsmasq_dhcp_options:
   - tag:edgecore,114,http://metalbox/sonic/sonic-broadcom-enterprise-base-4.4.2.bin
+dnsmasq_dhcp_boot:
+  - tag:edgecore,http://metalbox/ztp.json
 
 ##########################################################
 # httpd


### PR DESCRIPTION
Configure dnsmasq to serve ztp.json via DHCP boot option for EdgeCore devices, enabling Zero Touch Provisioning alongside the existing SONIC image serving capability.