### PR TITLE
Remove redfish_system_id from conductor config

### DIFF
--- a/environments/manager/files/conductor.yml
+++ b/environments/manager/files/conductor.yml
@@ -5,7 +5,6 @@ ironic_parameters:
     redfish_username: "{{ remote_board_username }}"
     redfish_password: "{{ remote_board_password }}"
     redfish_address: "https://{{ remote_board_address }}"
-    redfish_system_id: /redfish/v1/Systems/1
     redfish_verify_ca: False
     deploy_kernel: ironic-agent-kernel
     deploy_ramdisk: ironic-agent-initramfs


### PR DESCRIPTION
Some devices do not use `1` as the system ID. We do however only operate devices with a single redfish system. By simply omitting `redfish_system_id` ironic will automatically pick the only available system ([1]).

[1]
https://docs.openstack.org/ironic/latest/admin/drivers/redfish.html#registering-a-node-with-the-redfish-driver