### PR TITLE
Add support for versioned export images in mount/unmount scripts

### DIFF
--- a/scripts/mount-images.sh
+++ b/scripts/mount-images.sh
@@ -9,22 +9,44 @@ if [ ! -d "$DIR" ]; then
     exit 1
 fi
 
-echo "Looking for *.img files in: $DIR"
+echo "Looking for *.img, *-export.img, and *-export-*.img files in: $DIR"
 
 # Find all *.img files in the directory
 IMG_FILES=("$DIR"/*.img)
 
-# Check if any .img files were found
-if [ ! -e "${IMG_FILES[0]}" ]; then
-    echo "No *.img files found in $DIR"
+# Find all *-export.img files
+EXPORT_IMG_FILES=("$DIR"/*-export.img)
+
+# Find all *-export-*.img files and sort them by version/date
+EXPORT_VERSIONED_FILES=()
+if compgen -G "$DIR/*-export-*.img" > /dev/null; then
+    # Get all export files and sort by version/date (newest first)
+    mapfile -t EXPORT_VERSIONED_FILES < <(find "$DIR" -name "*-export-*.img" -printf '%f\n' | sort -V -r | head -1 | xargs -I {} find "$DIR" -name "{}")
+fi
+
+# Combine all file types
+ALL_FILES=()
+if [ -e "${IMG_FILES[0]}" ]; then
+    ALL_FILES+=("${IMG_FILES[@]}")
+fi
+if [ -e "${EXPORT_IMG_FILES[0]}" ]; then
+    ALL_FILES+=("${EXPORT_IMG_FILES[@]}")
+fi
+if [ ${#EXPORT_VERSIONED_FILES[@]} -gt 0 ]; then
+    ALL_FILES+=("${EXPORT_VERSIONED_FILES[@]}")
+fi
+
+# Check if any files were found
+if [ ${#ALL_FILES[@]} -eq 0 ]; then
+    echo "No *.img, *-export.img, or *-export-*.img files found in $DIR"
     exit 0
 fi
 
 # Counter for loop devices
 LOOP_NUM=0
 
-# Process each .img file
-for IMG_FILE in "${IMG_FILES[@]}"; do
+# Process each image file
+for IMG_FILE in "${ALL_FILES[@]}"; do
     if [ -f "$IMG_FILE" ]; then
         LOOP_DEVICE="/dev/loop${LOOP_NUM}"
         

--- a/scripts/unmount-images.sh
+++ b/scripts/unmount-images.sh
@@ -21,7 +21,7 @@ for LOOP_DEVICE in $LOOP_DEVICES; do
     # Get the backing file for this loop device
     BACKING_FILE=$(sudo losetup -l | grep "^$LOOP_DEVICE" | awk '{print $6}')
     
-    # Check if it's an .img file
+    # Check if it's an .img file (including *-export.img and *-export-*.img)
     if [[ "$BACKING_FILE" == *.img ]]; then
         echo "Unmounting $LOOP_DEVICE (backing file: $BACKING_FILE)"
         if sudo losetup -d "$LOOP_DEVICE"; then


### PR DESCRIPTION
Extend mount-images.sh and unmount-images.sh to support *-export.img and *-export-*.img file patterns. The scripts now automatically detect and select the newest version based on version/date sorting for *-export-*.img files.

AI-assisted: Claude Code