### PR TITLE
Add ESP config to ironic

### DIFF
--- a/environments/kolla/files/overlays/ironic/ironic-conductor.conf
+++ b/environments/kolla/files/overlays/ironic/ironic-conductor.conf
@@ -1,6 +1,10 @@
 [DEFAULT]
 enabled_network_interfaces = noop
 default_network_interface = noop
+grub_config_path = EFI/ubuntu/grub.cfg
 
 [deploy]
 external_callback_url = http://{{ ironic_external_callback_url_interface_address | put_address_in_context('url') }}:{{ ironic_api_port }}
+
+[conductor]
+bootloader = http://metalbox/esp.img


### PR DESCRIPTION
Note that this config assumes that the ESP image is based on ubuntu and placed available from the httpd running on the metalbox

https://docs.openstack.org/ironic/latest/install/configure-esp.html