### PR TITLE
Disable ironic-http and ironic-tftp

### DIFF
--- a/inventory/99-overwrite
+++ b/inventory/99-overwrite
@@ -7,3 +7,7 @@
 # in the cfg-generics repository.
 #
 # https://github.com/osism/cfg-generics/tree/main/inventory
+
+[ironic-tftp]
+
+[ironic-http]


### PR DESCRIPTION
Both services are unused. Since they are enabled by default and overrides would require to add a deeply nested dict to the configuration, their groups are simply removed.