### PR TITLE
Add ironic external_callback_url

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -22,3 +22,7 @@ om_enable_rabbitmq_high_availability: false
 om_enable_rabbitmq_quorum_queues: false
 
 enable_ironic_agent_download_images: false
+
+ironic_external_callback_url_interface: loopback0
+ironic_external_callback_url_address_family: ipv6
+ironic_external_callback_url_interface_address: "{{ 'ironic_external_callback_url' | kolla_address }}"

--- a/environments/kolla/files/overlays/ironic/ironic-conductor.conf
+++ b/environments/kolla/files/overlays/ironic/ironic-conductor.conf
@@ -1,3 +1,6 @@
 [DEFAULT]
 enabled_network_interfaces = noop
 default_network_interface = noop
+
+[deploy]
+external_callback_url = http://{{ ironic_external_callback_url_interface_address | put_address_in_context('url') }}/ironic/api


### PR DESCRIPTION
Add ironic `external_callback_url` so that IPA may communicate with the ironic API.