### PR TITLE
Add ironic deploy/http_url parameter

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -23,6 +23,7 @@ om_enable_rabbitmq_quorum_queues: false
 
 enable_ironic_agent_download_images: false
 
-ironic_external_callback_url_interface: loopback0
-ironic_external_callback_url_address_family: ipv6
-ironic_external_callback_url_interface_address: "{{ 'ironic_external_callback_url' | kolla_address }}"
+ironic_external_interface: loopback0
+ironic_external_address_family: ipv6
+ironic_external_interface_address: "{{ 'ironic_external' | kolla_address }}"
+ironic_http_url: "http://{{ ironic_external_interface_address | put_address_in_context('url') }}/ironic"

--- a/environments/kolla/files/overlays/ironic/ironic-conductor.conf
+++ b/environments/kolla/files/overlays/ironic/ironic-conductor.conf
@@ -5,6 +5,7 @@ grub_config_path = EFI/ubuntu/grub.cfg
 
 [deploy]
 external_callback_url = http://{{ ironic_external_callback_url_interface_address | put_address_in_context('url') }}:{{ ironic_api_port }}
+external_http_url = http://metalbox/ironic
 
 [conductor]
 bootloader = http://metalbox/esp.img


### PR DESCRIPTION
Point the ironic conductor to the httpd `/ironic` path as its `deploy/http_url`.