### PR TITLE
Fix ironic external_callback_url

### DIFF
--- a/environments/kolla/files/overlays/ironic/ironic-conductor.conf
+++ b/environments/kolla/files/overlays/ironic/ironic-conductor.conf
@@ -3,4 +3,4 @@ enabled_network_interfaces = noop
 default_network_interface = noop
 
 [deploy]
-external_callback_url = http://{{ ironic_external_callback_url_interface_address | put_address_in_context('url') }}/ironic/api
+external_callback_url = http://{{ ironic_external_callback_url_interface_address | put_address_in_context('url') }}:{{ ironic_api_port }}


### PR DESCRIPTION
The ironic API proxy listens on the ironic port.