### PR TITLE
Add static metalbox hosts entry

### DIFF
--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -18,8 +18,10 @@ docker_insecure_registries:
 
 # hosts
 hosts_type: template
+hosts_group_name: none
 hosts_additional_entries:
   api.metalbox.osism.xyz: 192.168.42.10
+  metalbox: 192.168.42.10
 
 # network
 network_allow_service_restart: true


### PR DESCRIPTION
This way it can be ensured that no other entries will show up in /etc/hosts.