### PR TITLE
Enable manager listener service

### DIFF
--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -25,6 +25,7 @@ ara_server_host: 192.168.42.10
 ##########################################################
 # listener
 
+enable_listener: true
 manager_listener_broker_hosts:
   - 192.168.42.10
 manager_listener_broker_username: openstack


### PR DESCRIPTION
The listener service is disabled by default, but is required on metalbox to listen for ironic notifications and write ironic state back into netbox.