### PR TITLE
[CIMC-COnfig] Test login after password change

### DIFF
--- a/environments/manager/playbook-cimc-config.yml
+++ b/environments/manager/playbook-cimc-config.yml
@@ -98,6 +98,15 @@
             url_password: "{{ redfish_default_password }}"
             <<: *uri_defaults
 
+        - name: Test login
+          delegate_to: localhost
+          retries: 12
+          delay: 5
+          ansible.builtin.uri:
+            url: "{{ redfish_scheme }}://{{ inventory_hostname }}{{ redfish_basepath }}"
+            url_password: "{{ hostvars[inventory_hostname]['redfish_password'] | default(redfish_password) }}"
+            <<: *uri_defaults
+
     - name: Get Manager Interface Information
       delegate_to: localhost
       register: manager_nic


### PR DESCRIPTION
After changing the CIMC admin user's password, logging in with the newly set password might fail immediately afterwards. Therefore a test login is done with a certain amount of retries.