### PR TITLE
Fix ansible-lint for cimc-config

### DIFF
--- a/environments/manager/playbook-cimc-config.yml
+++ b/environments/manager/playbook-cimc-config.yml
@@ -14,7 +14,7 @@
       vars:
         string_items: "{{ item | dict2items | selectattr('value', 'string') | items2dict }}"
         sequence_items: "{{ item | dict2items | rejectattr('value', 'string') | selectattr('value', 'sequence') }}"
-        api_filter: "{{ (sequence_items | map(attribute='key') | zip(sequence_items | map(attribute='value') | map('join', ',')) + string_items | items) | map('join', '=') | join(' ') }}"
+        api_filter: "{{ (sequence_items | map(attribute='key') | zip(sequence_items | map(attribute='value') | map('join', ',')) + string_items | items) | map('join', '=') | join(' ') }}"  # liniting fails on "string_items | items" with "Error rendering template: Can only get item pairs from a mapping." # noqa jinja[invalid]
       ansible.builtin.set_fact:
         netbox_devices: >-
           {{


### PR DESCRIPTION
ansible-lint complains about

```
Failed: 1 failure(s), 0 warning(s) on 85 files. Last profile that met the validation criteria was 'min'.
jinja[invalid]: Error rendering template: Can only get item pairs from a mapping.
environments/manager/playbook-cimc-config.yml:17:21 Task/Handler: Gather NetBox devices
```

which is caused by

```
string_items | items
```

`string_items` is a mapping and adding a default empty map

```
string_items | default({}) | items
```

does not fix this. Therefore the rule is ignored for this line.
