### PR TITLE
manager: add managed-by-ironic to netbox_filter_inventory

### DIFF
--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -74,6 +74,7 @@ netbox_filter_inventory:
   - state: active
     site: Discworld
     tag:
+      - managed-by-ironic
       - managed-by-osism
 netbox_role_mapping: {}
 netbox_data_types:


### PR DESCRIPTION
Do not add managed-by-metalbox devices to the manager inventory.