### PR TITLE
zuul: use /data/ubuntu-noble/ instead of /data/ubuntu/

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -54,11 +54,12 @@
     run: zuul/mirror-debian-packages.yml
     timeout: 16200
     files:
-      - "^zuul/mirror-debian-packages.yml"
-      - "^zuul/pre-mirror-debian-packages.yml"
+      - "^zuul/files/Containerfile"
       - "^zuul/files/create-mirror.sh"
       - "^zuul/files/packages.list"
       - "^zuul/files/repositories.conf"
+      - "^zuul/mirror-debian-packages.yml"
+      - "^zuul/pre-mirror-debian-packages.yml"
 
 - job:
     name: metalbox-mirror-container-images

--- a/zuul/files/Containerfile
+++ b/zuul/files/Containerfile
@@ -1,4 +1,4 @@
 FROM registry.osism.tech/osism/rsync:latest
 
-# Copy repository content from build context to /data/ubuntu/
-COPY . /data/ubuntu/
+# Copy repository content from build context to /data/ubuntu-noble/
+COPY . /data/ubuntu-noble/


### PR DESCRIPTION
This ways it's possible to use multiple Ubuntu releases on the same metalbox.