### PR TITLE
Add site validation check to deploy-manager script

### DIFF
--- a/scripts/deploy-manager.sh
+++ b/scripts/deploy-manager.sh
@@ -15,6 +15,18 @@ wait_for_container_healthy() {
     done
 }
 
+# Validate that the site name has been configured
+if grep -q "Discworld" /opt/configuration/environments/manager/configuration.yml; then
+    echo "ERROR: Default site name 'Discworld' detected in configuration"
+    echo ""
+    echo "Please set your actual site name before deploying."
+    echo "Run the following command with your site name:"
+    echo ""
+    echo "  netbox-site.sh <your_site_name>"
+    echo ""
+    exit 1
+fi
+
 pushd /opt/configuration/environments/manager
 bash run.sh manager
 popd


### PR DESCRIPTION
Prevent deployment when default 'Discworld' site name is still present in the configuration. This ensures users configure their actual site name via netbox-site.sh before deploying the manager.

The validation check provides clear error messages and instructions for remediation when the default site name is detected.

AI-assisted: Claude Code