### PR TITLE
Wait for cloud-init to finish before deploying netbox

### DIFF
--- a/scripts/deploy-netbox.sh
+++ b/scripts/deploy-netbox.sh
@@ -15,6 +15,8 @@ wait_for_container_healthy() {
     done
 }
 
+until stat /var/lib/cloud/instance/boot-finished 2>/dev/null; do echo Wait for cloud-init to finish; sleep 1; done
+
 pushd /opt/configuration/environments/manager
 bash run.sh netbox
 popd


### PR DESCRIPTION
Added a wait loop to ensure cloud-init has completed its initialization before running the netbox deployment. This prevents potential race conditions where netbox deployment might start before the system is fully configured.