### PR TITLE
sonic: fix permissions for sonic import directory

### DIFF
--- a/scripts/sonic-import.sh
+++ b/scripts/sonic-import.sh
@@ -225,7 +225,7 @@ fi
 echo -e "${YELLOW}Found ${#FOUND_FILES[@]} file(s) to copy${NC}"
 
 # Create destination directory if it doesn't exist
-sudo mkdir -p "$SONIC_DEST_DIR"
+sudo mkdir -p -m 0755 "$SONIC_DEST_DIR"
 sudo chown -R dragon: "$SONIC_DEST_DIR"
 
 # Copy all found files to destination


### PR DESCRIPTION
* currently the ZTP for sonic fails, since the permissions of the $SONIC_DEST_DIR are not set correctly
* this commit extends the mkdir command which creates the directory to also set the correct permissions