### PR TITLE
manager: add pynetbox to the requirements

### DIFF
--- a/environments/manager/requirements.txt
+++ b/environments/manager/requirements.txt
@@ -4,3 +4,4 @@ ansible-pylibssh==1.2.2
 debops==3.2.4
 netaddr==1.3.0
 paramiko==3.5.1
+pynetbox==7.5.0


### PR DESCRIPTION
This enables the use of a Netbox for inventory during deployment of the manager.