### PR TITLE
Extended NetBox config script to set managed site

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,31 +44,29 @@
 5. Run `deploy-netbox.sh` to deploy the NetBox service.
 6. Run `netbox-manage.sh` to initialise the NetBox service. Note that this can take a
    couple of minutes to complete depending on the size of your installation.
-7. Set the managed site by running `netbox-site.sh SITE`
-   (replace `SITE` with the slug name of the site managed by this Metalbox).
-8. Run `get-netbox-config.sh NODE` to get the specific configuration for this Metalbox from
+7. Run `get-netbox-config.sh NODE` to get the specific configuration for this Metalbox from
    the NetBox. Replace `NODE` with the name of the Metalbox device in the NetBox.
-9. Run `deploy-manager.sh` to deploy the OSISM manager service.
-10. Run `osism sync inventory` to sync the inventory.
-11. Run `osism apply hosts` to sync the `/etc/hosts` file.
-12. Run `osism apply network` and `osism apply frr` to sync the network configuration.
-13. Run `osism apply facts` to sync the facts.
-14. Run `osism apply chrony` to sync the NTP configuration.
-15. Use as Ubuntu repository server.
+8. Run `deploy-manager.sh` to deploy the OSISM manager service.
+9. Run `osism sync inventory` to sync the inventory.
+10. Run `osism apply hosts` to sync the `/etc/hosts` file.
+11. Run `osism apply network` and `osism apply frr` to sync the network configuration.
+12. Run `osism apply facts` to sync the facts.
+13. Run `osism apply chrony` to sync the NTP configuration.
+14. Use as Ubuntu repository server.
     * If the Metalbox is to be used as an Ubuntu repository server for nodes inside the
       Cloudpod do all steps in "Using the Metalbox as an Ubuntu repository server".
     *  <ins>OR</ins> Disable the use of the Metalbox as repository server by running
       `disable-repository.sh`.
-16. Import of the SONiC files.
+15. Import of the SONiC files.
     * Use the file `sonic-export.img` as virtual media (vHDD) and run `deploy-sonic.sh` to deploy
       the SONiC ZTP services. Afterwards remove the virtual media (vHDD).
     * <ins>OR</ins> Copy the `sonic-export.img` file to `/home/dragon` and run `mount-images.sh`.
       Run `deploy-sonic.sh` to deploy the SONiC ZTP services. Afterwards run `unmount-images.sh`.
-17. Run `deploy-infrastructure.sh` to deploy the infrastructure services.
-18. Run `deploy-openstack.sh` to Deploy the OpenStack services.
-19. Upload the Ironic image files to `/opt/httpd/data/root`.
-20. Run `osism sync ironic` to sync the baremetal nodes.
-21. Optional: If the Metalbox is to be used as a container registry for nodes inside
+16. Run `deploy-infrastructure.sh` to deploy the infrastructure services.
+17. Run `deploy-openstack.sh` to Deploy the OpenStack services.
+18. Upload the Ironic image files to `/opt/httpd/data/root`.
+19. Run `osism sync ironic` to sync the baremetal nodes.
+20. Optional: If the Metalbox is to be used as a container registry for nodes inside
     the Cloudpod do all steps in "Using Metalbox as a full container registry".
 
 ### Optional steps


### PR DESCRIPTION
Read device site from NetBox API and call netbox-site.sh script with site slug to automatically set the managed site during device configuration fetching.

- Added subprocess module import
- Created set_netbox_site() function to call netbox-site.sh
- Modified fetch_device_config() to return site along with config
- Updated main() to extract site slug and set managed site
- Added appropriate error handling for missing site and script failures
- Added logging for site operations

AI-assisted: Claude Code