### PR TITLE
Remove loopback0 device from the inventories

### DIFF
--- a/environments/manager/group_vars/all/network.yml
+++ b/environments/manager/group_vars/all/network.yml
@@ -1,9 +1,6 @@
 ---
 network_ethernets: {}
 network_dummy_devices:
-  loopback0:
-    link-local:
-      - ipv6
   metalbox:
     addresses:
       - 192.168.42.10/24

--- a/inventory/group_vars/all/network.yml
+++ b/inventory/group_vars/all/network.yml
@@ -1,9 +1,0 @@
----
-network_ethernets: {}
-network_dummy_devices:
-  loopback0:
-    link-local:
-      - ipv6
-  metalbox:
-    addresses:
-      - 192.168.42.10/24


### PR DESCRIPTION
The device is not required for the deployment of the manager service and is added with the network configuration if it is configured in the NetBox.

Part of osism/metalbox#255