### PR TITLE
Fix loop device handling in sonic-import.sh

### DIFF
--- a/scripts/sonic-import.sh
+++ b/scripts/sonic-import.sh
@@ -193,7 +193,7 @@ if [[ ${#FOUND_FILES[@]} -eq 0 ]]; then
 
         if [[ -n "$mount_point" ]]; then
             echo -e "Checking mounted loopback device: $device at $mount_point"
-            search_on_device "$device" "$mount_point" "yes"
+            search_on_device "$device" "$mount_point" "yes" || true
         else
             # Not mounted, try to mount temporarily
             echo -e "Checking unmounted loopback device: $device"
@@ -206,7 +206,7 @@ if [[ ${#FOUND_FILES[@]} -eq 0 ]]; then
 
             # Try to mount it
             if sudo mount -t ext4 -o ro "$device" "$TEMP_MOUNT_DIR" 2>/dev/null; then
-                search_on_device "$device" "$TEMP_MOUNT_DIR" "no"
+                search_on_device "$device" "$TEMP_MOUNT_DIR" "no" || true
             else
                 echo -e "  Could not mount $device"
             fi


### PR DESCRIPTION
The script was exiting prematurely when files were not found on the first loop device due to missing error handling. Added '|| true' to both search_on_device calls in the loop device section (lines 196 and 209) to allow the script to continue checking all available loop devices.

This matches the working pattern already implemented in octavia-import.sh and ensures proper handling when multiple loop devices are present.

AI-assisted: Claude Code