### PR TITLE
Add scripts for single image export and import

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,14 @@ netbox-manager run --limit 300-node10
 
 1. The container registry must be updated first in order to receive OpenStack service updates
 2. Run `update-openstack.sh` to update the OpenStack services
+
+## Update from a single image on the container registry
+
+Replace `registry.osism.tech/osism/inventory-reconciler:latest` and `registry-delta-YYYYMMDD-HHMM.tar.gz`
+as needed.
+
+1. Run `scripts/singe-image-export.sh registry.osism.tech/osism/inventory-reconciler:latest` on a local
+   system to create a `registry-delta-YYYYMMDD-HHMM.tar.gz` file
+2. Copy `registry-delta-YYYYMMDD-HHMM.tar.gz` to `/home/dragon` on the Metalbox node
+3. Run `single-image-import.sh registry-delta-YYYYMMDD-HHMM.tar.gz` on the Metalbox node to import
+   the image

--- a/scripts/single-image-export.sh
+++ b/scripts/single-image-export.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Export a single Docker image to a tar.gz archive for delta updates
+#
+# Usage: ./single-image-export.sh <image>
+#
+# Examples:
+#   ./single-image-export.sh osism/inventory-reconciler:latest
+#   ./single-image-export.sh osism/ara-server:1.7.3
+#   ./single-image-export.sh kolla/nova-api:2024.2
+#   ./single-image-export.sh dockerhub/library/redis:7.4.7-alpine
+#
+# The image parameter should include the namespace prefix:
+#   - dockerhub/  for DockerHub images (e.g., dockerhub/library/redis:7.4.7-alpine)
+#   - osism/      for OSISM manager images (e.g., osism/ara-server:1.7.3)
+#   - kolla/      for Kolla images (e.g., kolla/nova-api:2024.2)
+
+set -euo pipefail
+
+DOCKER_REGISTRY="${DOCKER_REGISTRY:-registry.osism.tech}"
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <image>"
+    echo ""
+    echo "Examples:"
+    echo "  $0 osism/inventory-reconciler:latest"
+    echo "  $0 osism/ara-server:1.7.3"
+    echo "  $0 kolla/nova-api:2024.2"
+    echo "  $0 dockerhub/library/redis:7.4.7-alpine"
+    exit 1
+fi
+
+IMAGE="$1"
+
+# Strip registry prefix if provided (e.g., registry.osism.tech/osism/foo -> osism/foo)
+if [[ "${IMAGE}" == registry.osism.tech/* ]]; then
+    IMAGE="${IMAGE#registry.osism.tech/}"
+elif [[ "${IMAGE}" == registry.osism.cloud/* ]]; then
+    IMAGE="${IMAGE#registry.osism.cloud/}"
+fi
+
+# Generate output filename with timestamp
+TIMESTAMP=$(date +%Y%m%d-%H%M)
+OUTPUT_FILE="registry-delta-${TIMESTAMP}.tar.gz"
+TEMP_DIR=$(mktemp -d)
+
+# Cleanup function
+cleanup() {
+    echo "==> Cleaning up..."
+    rm -rf "${TEMP_DIR}"
+}
+
+# Set trap for cleanup on exit
+trap cleanup EXIT
+
+# Parse the image path to determine the destination path
+# Input format: namespace/image:tag (e.g., dockerhub/library/redis:7.4.7-alpine)
+# For dockerhub: strip the 'dockerhub/' prefix
+# For osism/kolla: keep as-is
+if [[ "${IMAGE}" == dockerhub/* ]]; then
+    DEST_IMAGE="${IMAGE#dockerhub/}"
+else
+    DEST_IMAGE="${IMAGE}"
+fi
+
+echo "==> Exporting image: ${IMAGE}"
+echo "==> Source registry: ${DOCKER_REGISTRY}"
+echo "==> Destination name: ${DEST_IMAGE}"
+echo "==> Output file: ${OUTPUT_FILE}"
+
+# Export image using skopeo to docker-archive format
+ARCHIVE_FILE="${TEMP_DIR}/image.tar"
+echo "==> Copying image to docker-archive format..."
+skopeo copy --retry-times 2 \
+    "docker://${DOCKER_REGISTRY}/${IMAGE}" \
+    "docker-archive:${ARCHIVE_FILE}:${DEST_IMAGE}"
+
+# Create manifest file with image name for import
+echo "${DEST_IMAGE}" > "${TEMP_DIR}/manifest.txt"
+
+# Create final tar.gz with image archive and manifest
+echo "==> Creating ${OUTPUT_FILE}..."
+tar -czf "${OUTPUT_FILE}" -C "${TEMP_DIR}" image.tar manifest.txt
+
+# Get and display file size
+if [[ -f "${OUTPUT_FILE}" ]]; then
+    SIZE=$(du -h "${OUTPUT_FILE}" | cut -f1)
+    echo "==> Export complete: ${OUTPUT_FILE} (${SIZE})"
+
+    # Generate checksum
+    sha256sum "${OUTPUT_FILE}" > "${OUTPUT_FILE}.CHECKSUM"
+    echo "==> Checksum file: ${OUTPUT_FILE}.CHECKSUM"
+else
+    echo "ERROR: Export file not created!"
+    exit 1
+fi
+
+echo "==> Done!"

--- a/scripts/single-image-import.sh
+++ b/scripts/single-image-import.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Import a registry delta tar.gz to the running registry on localhost:5001
+#
+# Usage: ./single-image-import.sh <tarball>
+#
+# Example:
+#   ./single-image-import.sh registry-delta-20250124-1430.tar.gz
+#
+# This script:
+#   1. Extracts the tarball containing image.tar and manifest.txt
+#   2. Uses skopeo to copy the image to localhost:5001
+#
+# Prerequisites:
+#   - Registry must already be running on localhost:5001
+
+set -euo pipefail
+
+TARGET_REGISTRY="${TARGET_REGISTRY:-localhost:5001}"
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <tarball>"
+    echo ""
+    echo "Example:"
+    echo "  $0 registry-delta-20250124-1430.tar.gz"
+    echo ""
+    echo "Environment variables:"
+    echo "  TARGET_REGISTRY - Target registry (default: localhost:5001)"
+    exit 1
+fi
+
+TARBALL="$1"
+
+if [[ ! -f "${TARBALL}" ]]; then
+    echo "ERROR: Tarball not found: ${TARBALL}"
+    exit 1
+fi
+
+TEMP_DIR=$(mktemp -d)
+
+# Cleanup function
+cleanup() {
+    echo "==> Cleaning up..."
+    rm -rf "${TEMP_DIR}"
+}
+
+# Set trap for cleanup on exit
+trap cleanup EXIT
+
+echo "==> Importing from: ${TARBALL}"
+echo "==> Target registry: ${TARGET_REGISTRY}"
+
+# Extract tarball
+echo "==> Extracting tarball..."
+tar -xzf "${TARBALL}" -C "${TEMP_DIR}"
+
+# Read image name from manifest
+if [[ ! -f "${TEMP_DIR}/manifest.txt" ]]; then
+    echo "ERROR: manifest.txt not found in tarball"
+    exit 1
+fi
+
+DEST_IMAGE=$(cat "${TEMP_DIR}/manifest.txt")
+echo "==> Image name: ${DEST_IMAGE}"
+
+# Copy image to target registry using skopeo
+echo "==> Copying image to ${TARGET_REGISTRY}/${DEST_IMAGE}..."
+skopeo copy --retry-times 2 \
+    --dest-tls-verify=false \
+    "docker-archive:${TEMP_DIR}/image.tar" \
+    "docker://${TARGET_REGISTRY}/${DEST_IMAGE}"
+
+echo "==> Import complete!"


### PR DESCRIPTION
Add two scripts to handle delta updates for container images:

- single-image-export.sh: Export a single image from registry.osism.tech to a tar.gz using skopeo and docker-archive format
- single-image-import.sh: Import the tar.gz to the running registry on localhost:5001 using skopeo

AI-assisted: Claude Code