### PR TITLE
Workaround unversioned change in CISCO RF extension

### DIFF
--- a/environments/manager/playbook-cimc-config.yml
+++ b/environments/manager/playbook-cimc-config.yml
@@ -399,12 +399,19 @@
 
                 - name: Configure NetworkPort
                   vars:
-                    oem_config:
+                    oem_config_v1:
                       Oem:
                         Cisco:
                           VicPort:
                             AdminFecMode: "Off"
                             AdminLinkSpeed: "Auto"
+                    oem_config_v2:
+                      Oem:
+                        Cisco:
+                          VicPort:
+                            AdminFecMode: "Off"
+                            ConfiguredLinkSpeed: "Auto"
+                    oem_config: "{{ oem_config_v1 if 'AdminLinkSpeed' in item.json.Oem.Cisco.VicPort else oem_config_v2 }}"
                   delegate_to: localhost
                   ansible.builtin.uri:
                     url: "{{ redfish_scheme }}://{{ inventory_hostname }}{{ item.item }}"


### PR DESCRIPTION
CISCO changed an attribute of their redfish `NetworkPort` OEM extension without changing the version included in the object type. As a workaround we check whether the fetched object contains the expected attribute and pick the correct predefined updates.