### PR TITLE
Fix device state in netbox filter

### DIFF
--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -68,17 +68,17 @@ netbox_service_allow_restart: false
 netbox_api_url: "http://192.168.42.10:8121"
 
 netbox_filter_conductor_ironic:
-  - state: active
+  - status: active
     site: Discworld
     tag:
       - managed-by-ironic
 netbox_filter_conductor_sonic:
-  - state: active
+  - status: active
     site: Discworld
     tag:
       - managed-by-metalbox
 netbox_filter_inventory:
-  - state: active
+  - status: active
     site: Discworld
     tag:
       - managed-by-ironic


### PR DESCRIPTION
The filter for device state `active` does not work currently. According to the API docs ([1]) the correct query parameter is actually `status`.

Depends-On: https://github.com/osism/python-osism/pull/1929

[1]
https://demo.netbox.dev/api/schema/swagger-ui/#/dcim/dcim_devices_list