### PR TITLE
Configure automated cleaning

### DIFF
--- a/environments/kolla/files/overlays/ironic/ironic-conductor.conf
+++ b/environments/kolla/files/overlays/ironic/ironic-conductor.conf
@@ -10,6 +10,9 @@ enabled_boot_interfaces = redfish-virtual-media
 [deploy]
 external_callback_url = http://metalbox:{{ ironic_api_port }}
 external_http_url = http://metalbox.osism.xyz/ironic
+erase_devices_priority=0
+erase_devices_metadata_priority=0
 
 [conductor]
 bootloader = http://metalbox/osism-esp.raw
+clean_step_priority_override=deploy.erase_devices_express:95

--- a/environments/kolla/files/overlays/ironic/policy.yaml
+++ b/environments/kolla/files/overlays/ironic/policy.yaml
@@ -1,0 +1,1 @@
+"baremetal:node:disable_cleaning": "role:admin"


### PR DESCRIPTION
Automated cleaning will be orchestrated on a per node basis in `python-osism`.

* Allow disabling automated cleaning by project scoped tokens, because that is what is used in `python-osism`
* Configure automated cleaning to use `deploy.erase_devices_express`, which does either secure erase or removal of metadata.

Depends-On: https://github.com/osism/container-images-kolla/pull/689