### PR TITLE
Add tool to generate container image mirror lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,26 @@ as needed.
 3. Run `single-image-import.sh registry-delta-YYYYMMDD-HHMM.tar.gz` on the Metalbox node to import
    the image
 
+## Maintaining the container image mirror list
+
+The `images` and `images_manager` sections in `zuul/vars/container-images.yml`
+are generated from the [osism/release](https://github.com/osism/release) repository.
+The script computes the union of all image versions across a major release series
+so the mirror can serve sites on any minor release.
+
+```
+python3 scripts/generate_image_list.py
+```
+
+By default the script targets the latest major release. Use `--major N` to
+target a specific series, `--release-repo PATH` to use a local checkout
+instead of fetching from GitHub, and `--keep-latest` to preserve existing
+`:latest` tags instead of expanding them to pinned versions.
+
+Which images the Metalbox needs is defined in `scripts/metalbox-images.yml`.
+The script will error if new images appear upstream that are not listed
+in either the `images` or `exclude` section of that file.
+
 ## Troubleshooting
 
 ### Manual prepartion of the ironic volume

--- a/scripts/generate_image_list.py
+++ b/scripts/generate_image_list.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Generate zuul/vars/container-images.yml from osism/release data."""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+GITHUB_API_URL = "https://api.github.com/repos/osism/release/contents/"
+GITHUB_RAW_URL = "https://raw.githubusercontent.com/osism/release/main/"
+
+VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse_version(name):
+    """Parse a version string like '9.3.1' into (major, minor, patch).
+    Returns None for non-version strings and release candidates."""
+    m = VERSION_RE.match(name)
+    if m is None:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def discover_versions(release_repo, major=None):
+    """Return list of version strings for non-RC releases.
+    release_repo: local path (str/Path) or None for GitHub.
+    major: if set, filter to this major version only."""
+    if release_repo is not None:
+        names = [p.name for p in Path(release_repo).iterdir() if p.is_dir()]
+    else:
+        names = _github_list_dirs()
+    result = []
+    for name in names:
+        v = parse_version(name)
+        if v is None:
+            continue
+        if major is not None and v[0] != major:
+            continue
+        result.append(name)
+    return result
+
+
+def _github_list_dirs():
+    """List directory names from the release repo root via GitHub API."""
+    req = urllib.request.Request(
+        GITHUB_API_URL,
+        headers={"Accept": "application/vnd.github.v3+json"},
+    )
+    with urllib.request.urlopen(req) as resp:
+        entries = json.loads(resp.read())
+    return [e["name"] for e in entries if e["type"] == "dir"]
+
+
+def fetch_file(release_repo, path):
+    """Fetch and YAML-parse a file from the release repo."""
+    if release_repo is not None:
+        file_path = Path(release_repo) / path
+        with open(file_path, encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    else:
+        url = GITHUB_RAW_URL + path
+        with urllib.request.urlopen(url) as resp:
+            return yaml.safe_load(resp.read())
+
+
+def fetch_image_mapping(release_repo):
+    """Fetch etc/images.yml: logical name -> image path."""
+    return fetch_file(release_repo, "etc/images.yml")
+
+
+def fetch_base_versions(release_repo, version):
+    """Fetch <version>/base.yml and return docker_images dict."""
+    data = fetch_file(release_repo, f"{version}/base.yml")
+    return data.get("docker_images", {})
+
+
+def collect_all_versions(release_repo, versions):
+    """Collect the union of docker_images across multiple releases.
+    Returns dict mapping logical name -> set of version tags."""
+    all_versions = {}
+    for version in versions:
+        images = fetch_base_versions(release_repo, version)
+        for name, tag in images.items():
+            all_versions.setdefault(name, set()).add(str(tag))
+    return all_versions
+
+
+def load_filter_config(path):
+    """Load the metalbox filter config."""
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return {
+        "images": data.get("images", []),
+        "exclude": data.get("exclude", []),
+        "unmanaged": data.get("unmanaged", []),
+        "unmanaged_manager": data.get("unmanaged_manager", []),
+    }
+
+
+def validate_filter(filter_names, image_mapping, all_versions, exclude_names=None):
+    """Validate filter against upstream data. Returns list of error messages.
+    Errors:
+    - Images in image_mapping with versions in all_versions but not in filter
+      or exclude list.
+    - Images in filter but not in image_mapping."""
+    errors = []
+    filter_set = set(filter_names)
+    exclude_set = set(exclude_names or [])
+    known = filter_set | exclude_set
+    upstream_with_versions = set(image_mapping.keys()) & set(all_versions.keys())
+
+    unknown = sorted(upstream_with_versions - known)
+    for name in unknown:
+        errors.append(
+            f"Image '{name}' exists in release repo with versions "
+            f"{sorted(all_versions[name])} but is not in the filter config. "
+            f"Add it to scripts/metalbox-images.yml or confirm it's not needed."
+        )
+
+    stale = sorted(filter_set - set(image_mapping.keys()))
+    for name in stale:
+        errors.append(
+            f"Image '{name}' is in the filter config but does not exist in "
+            f"release/etc/images.yml. Remove it from scripts/metalbox-images.yml."
+        )
+
+    no_versions = sorted(filter_set & set(image_mapping.keys()) - set(all_versions.keys()))
+    for name in no_versions:
+        errors.append(
+            f"Image '{name}' is in the filter config and in release/etc/images.yml "
+            f"but has no versions in any target release. Move it to unmanaged or "
+            f"exclude in scripts/metalbox-images.yml."
+        )
+
+    return errors
+
+
+def _collect_latest_images(zuul_path):
+    """Read the existing zuul file and return image names that use :latest."""
+    with open(zuul_path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    latest = set()
+    for entry in data.get("images", []) + data.get("images_manager", []):
+        if entry.endswith(":latest"):
+            latest.add(entry.rsplit(":latest", 1)[0])
+    return latest
+
+
+def generate_image_entries(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    filter_names,
+    image_mapping,
+    all_versions,
+    unmanaged,
+    unmanaged_manager,
+    keep_latest_for=None,
+):
+    """Generate sorted image:tag lists for the zuul file.
+    Returns (images, images_manager) where:
+    - images: entries with non-osism/ prefix (full path preserved)
+    - images_manager: entries with osism/ prefix (prefix stripped)
+    keep_latest_for: set of short image names (e.g. 'osism', 'ara-server')
+    that should emit only ':latest' instead of expanded versions."""
+    images = []
+    images_manager = []
+    keep = keep_latest_for or set()
+
+    for name in filter_names:
+        path = image_mapping[name]
+        if path.startswith("osism/"):
+            short = path[len("osism/") :]
+        else:
+            short = path
+        if short in keep:
+            tags = ["latest"]
+        else:
+            tags = sorted(all_versions.get(name, set()))
+        if path.startswith("osism/"):
+            for tag in tags:
+                images_manager.append(f"{short}:{tag}")
+        else:
+            for tag in tags:
+                images.append(f"{path}:{tag}")
+
+    images.extend(unmanaged)
+    images_manager.extend(unmanaged_manager)
+    images.sort()
+    images_manager.sort()
+    return images, images_manager
+
+
+def _write_yaml_list(f, key, items):
+    """Write a YAML key with a list of items using 2-space indented dashes."""
+    if not items:
+        f.write(f"{key}: []\n")
+        return
+    f.write(f"{key}:\n")
+    for item in items:
+        f.write(f"  - {item}\n")
+
+
+def update_zuul_file(path, images, images_manager):
+    """Update zuul/vars/container-images.yml in place.
+    Replaces images and images_manager, preserves all other keys."""
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    data["images"] = images
+    data["images_manager"] = images_manager
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---\n")
+        for key, value in data.items():
+            if isinstance(value, list):
+                _write_yaml_list(f, key, value)
+            else:
+                yaml.dump({key: value}, f, default_flow_style=False)
+            f.write("\n")
+
+
+def detect_latest_major(versions):
+    """Return the highest major version number from a list of version strings."""
+    return max(parse_version(v)[0] for v in versions)
+
+
+def run(release_repo, major, filter_path, zuul_path, keep_latest=False):
+    """Core logic, callable from tests without argparse."""
+    all_version_strings = discover_versions(release_repo)
+    if not all_version_strings:
+        print("ERROR: No release versions found.", file=sys.stderr)
+        return 1
+
+    if major is None:
+        major = detect_latest_major(all_version_strings)
+    print(f"Targeting major release series: {major}", file=sys.stderr)
+
+    target_versions = discover_versions(release_repo, major=major)
+    if not target_versions:
+        print(f"ERROR: No releases found for major version {major}.", file=sys.stderr)
+        return 1
+    print(f"Found releases: {sorted(target_versions)}", file=sys.stderr)
+
+    image_mapping = fetch_image_mapping(release_repo)
+    all_versions = collect_all_versions(release_repo, target_versions)
+
+    filter_config = load_filter_config(filter_path)
+    errors = validate_filter(
+        filter_config["images"],
+        image_mapping,
+        all_versions,
+        exclude_names=filter_config["exclude"],
+    )
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    keep_latest_for = set()
+    if keep_latest:
+        keep_latest_for = _collect_latest_images(zuul_path)
+        if keep_latest_for:
+            print(f"Keeping :latest for: {sorted(keep_latest_for)}", file=sys.stderr)
+
+    images, images_manager = generate_image_entries(
+        filter_config["images"],
+        image_mapping,
+        all_versions,
+        unmanaged=filter_config["unmanaged"],
+        unmanaged_manager=filter_config["unmanaged_manager"],
+        keep_latest_for=keep_latest_for,
+    )
+
+    update_zuul_file(zuul_path, images, images_manager)
+    print(f"Updated {zuul_path}", file=sys.stderr)
+    print(f"  images: {len(images)} entries", file=sys.stderr)
+    print(f"  images_manager: {len(images_manager)} entries", file=sys.stderr)
+    return 0
+
+
+def main(argv=None):
+    """CLI entry point: parse arguments and run."""
+    parser = argparse.ArgumentParser(
+        description="Generate images and images_manager in "
+        "zuul/vars/container-images.yml from osism/release data."
+    )
+    parser.add_argument(
+        "--major",
+        type=int,
+        default=None,
+        help="Major release series to target (default: latest non-RC).",
+    )
+    parser.add_argument(
+        "--release-repo",
+        type=str,
+        default=None,
+        help="Local path to osism/release checkout " "(default: fetch from GitHub).",
+    )
+    parser.add_argument(
+        "--keep-latest",
+        action="store_true",
+        help="Preserve existing :latest tags from the zuul file instead "
+        "of expanding to all pinned versions from the release repo.",
+    )
+    args = parser.parse_args(argv)
+
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parent
+
+    return run(
+        release_repo=args.release_repo,
+        major=args.major,
+        keep_latest=args.keep_latest,
+        filter_path=str(script_dir / "metalbox-images.yml"),
+        zuul_path=str(repo_root / "zuul" / "vars" / "container-images.yml"),
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/metalbox-images.yml
+++ b/scripts/metalbox-images.yml
@@ -1,0 +1,58 @@
+---
+# Images from the osism/release repo that the Metalbox needs to mirror.
+# Use logical names matching keys in release/etc/images.yml.
+# Run scripts/generate_image_list.py to check for new or removed images
+# upstream -- the script will error if this list is out of date.
+images:
+  - ara_server
+  - dnsdist
+  - dnsmasq
+  - gnmic
+  - inventory_reconciler
+  - kolla_ansible
+  - mariadb
+  - netbox
+  - osism
+  - osism_ansible
+  - pgautoupgrade
+  - postgres
+  - redis
+  - squid
+  - stepca
+  - tempest
+  - traefik
+  - vault
+
+# Images in the release repo that the Metalbox does not need to mirror.
+# Listed here so the script knows they were evaluated, not overlooked.
+exclude:
+  - adminer
+  - alerta
+  - ceph_ansible
+  - cgit
+  - fleet
+  - homer
+  - memcached
+  - nexus
+  - nginx
+  - openstack_database_exporter
+  - opentelemetry_collector
+  - osism_kubernetes
+  - phpmyadmin
+  - pushgateway
+  - registry
+  - scaphandre
+  - sonic_vs
+  - substation
+  - syft
+
+# Images not tracked by the release repo's base.yml versioning.
+# Passed through to the output as-is.
+unmanaged:
+  - library/httpd:alpine
+
+unmanaged_manager:
+  - openstackclient:2024.2
+  - osism-frontend:latest
+  - rsync:latest
+  - seed:latest

--- a/scripts/test_generate_image_list.py
+++ b/scripts/test_generate_image_list.py
@@ -1,0 +1,823 @@
+"""Tests for generate_image_list.py"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+# Allow running from any directory
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from generate_image_list import (
+    _collect_latest_images,
+    collect_all_versions,
+    detect_latest_major,
+    discover_versions,
+    fetch_base_versions,
+    fetch_image_mapping,
+    generate_image_entries,
+    load_filter_config,
+    parse_version,
+    run,
+    update_zuul_file,
+    validate_filter,
+)
+
+
+class TestParseVersion(unittest.TestCase):
+    def test_valid_version(self):
+        self.assertEqual(parse_version("9.3.1"), (9, 3, 1))
+
+    def test_valid_version_large(self):
+        self.assertEqual(parse_version("10.0.0"), (10, 0, 0))
+
+    def test_valid_version_zeros(self):
+        self.assertEqual(parse_version("1.0.0"), (1, 0, 0))
+
+    def test_rc_version_returns_none(self):
+        self.assertIsNone(parse_version("9.3.1rc1"))
+
+    def test_rc_version_dash_returns_none(self):
+        self.assertIsNone(parse_version("9.3.1-rc1"))
+
+    def test_non_version_string_returns_none(self):
+        self.assertIsNone(parse_version("etc"))
+
+    def test_partial_version_returns_none(self):
+        self.assertIsNone(parse_version("9.3"))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(parse_version(""))
+
+    def test_alpha_version_returns_none(self):
+        self.assertIsNone(parse_version("latest"))
+
+
+class TestDiscoverVersionsLocal(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmpdir.name)
+        # Create version dirs
+        for v in ["9.0.0", "9.1.0", "10.0.0", "10.1.0"]:
+            (self.repo / v).mkdir()
+        # Create non-version dirs
+        (self.repo / "etc").mkdir()
+        (self.repo / "main").mkdir()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_all_versions(self):
+        versions = discover_versions(self.repo)
+        self.assertCountEqual(versions, ["9.0.0", "9.1.0", "10.0.0", "10.1.0"])
+
+    def test_filter_by_major(self):
+        versions = discover_versions(self.repo, major=9)
+        self.assertCountEqual(versions, ["9.0.0", "9.1.0"])
+
+    def test_filter_by_major_10(self):
+        versions = discover_versions(self.repo, major=10)
+        self.assertCountEqual(versions, ["10.0.0", "10.1.0"])
+
+    def test_filter_by_major_no_match(self):
+        versions = discover_versions(self.repo, major=11)
+        self.assertEqual(versions, [])
+
+    def test_excludes_non_version_dirs(self):
+        versions = discover_versions(self.repo)
+        self.assertNotIn("etc", versions)
+        self.assertNotIn("main", versions)
+
+
+class TestFetchLocal(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmpdir.name)
+        etc_dir = self.repo / "etc"
+        etc_dir.mkdir()
+        images_data = {
+            "ara_server": "osism/ara-server",
+            "netbox": "osism/netbox",
+            "traefik": "traefik",
+        }
+        with open(etc_dir / "images.yml", "w") as f:
+            yaml.dump(images_data, f)
+
+        ver_dir = self.repo / "9.3.1"
+        ver_dir.mkdir()
+        base_data = {
+            "docker_images": {
+                "ara_server": "2024.1.3",
+                "netbox": "v4.1.11",
+                "traefik": "v3.3.4",
+            }
+        }
+        with open(ver_dir / "base.yml", "w") as f:
+            yaml.dump(base_data, f)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_fetch_image_mapping(self):
+        mapping = fetch_image_mapping(self.repo)
+        self.assertEqual(mapping["ara_server"], "osism/ara-server")
+        self.assertEqual(mapping["netbox"], "osism/netbox")
+        self.assertEqual(mapping["traefik"], "traefik")
+
+    def test_fetch_base_versions(self):
+        images = fetch_base_versions(self.repo, "9.3.1")
+        self.assertEqual(images["ara_server"], "2024.1.3")
+        self.assertEqual(images["netbox"], "v4.1.11")
+        self.assertEqual(images["traefik"], "v3.3.4")
+
+    def test_fetch_base_versions_missing_docker_images(self):
+        ver_dir = self.repo / "9.3.2"
+        ver_dir.mkdir()
+        with open(ver_dir / "base.yml", "w") as f:
+            yaml.dump({"other_key": "value"}, f)
+        images = fetch_base_versions(self.repo, "9.3.2")
+        self.assertEqual(images, {})
+
+
+class TestCollectAllVersions(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmpdir.name)
+        for version, images in [
+            ("9.0.0", {"ara_server": "1.0", "netbox": "v3.0"}),
+            ("9.1.0", {"ara_server": "1.1", "netbox": "v3.1", "traefik": "v2.0"}),
+        ]:
+            ver_dir = self.repo / version
+            ver_dir.mkdir()
+            with open(ver_dir / "base.yml", "w") as f:
+                yaml.dump({"docker_images": images}, f)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_union_of_versions(self):
+        all_versions = collect_all_versions(self.repo, ["9.0.0", "9.1.0"])
+        self.assertEqual(all_versions["ara_server"], {"1.0", "1.1"})
+        self.assertEqual(all_versions["netbox"], {"v3.0", "v3.1"})
+        self.assertEqual(all_versions["traefik"], {"v2.0"})
+
+    def test_single_version(self):
+        all_versions = collect_all_versions(self.repo, ["9.0.0"])
+        self.assertEqual(all_versions["ara_server"], {"1.0"})
+        self.assertNotIn("traefik", all_versions)
+
+    def test_empty_versions(self):
+        all_versions = collect_all_versions(self.repo, [])
+        self.assertEqual(all_versions, {})
+
+
+class TestLoadFilterConfig(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_load_with_both_keys(self):
+        path = Path(self.tmpdir.name) / "filter.yml"
+        with open(path, "w") as f:
+            yaml.dump(
+                {
+                    "images": ["ara_server", "netbox"],
+                    "unmanaged": ["library/httpd:alpine"],
+                },
+                f,
+            )
+        config = load_filter_config(path)
+        self.assertEqual(config["images"], ["ara_server", "netbox"])
+        self.assertEqual(config["unmanaged"], ["library/httpd:alpine"])
+
+    def test_missing_unmanaged_defaults_to_empty(self):
+        path = Path(self.tmpdir.name) / "filter.yml"
+        with open(path, "w") as f:
+            yaml.dump({"images": ["ara_server"]}, f)
+        config = load_filter_config(path)
+        self.assertEqual(config["images"], ["ara_server"])
+        self.assertEqual(config["unmanaged"], [])
+
+    def test_missing_images_defaults_to_empty(self):
+        path = Path(self.tmpdir.name) / "filter.yml"
+        with open(path, "w") as f:
+            yaml.dump({"unmanaged": ["library/httpd:alpine"]}, f)
+        config = load_filter_config(path)
+        self.assertEqual(config["images"], [])
+        self.assertEqual(config["unmanaged"], ["library/httpd:alpine"])
+
+    def test_exclude_key(self):
+        path = Path(self.tmpdir.name) / "filter.yml"
+        with open(path, "w") as f:
+            yaml.dump({"images": ["ara_server"], "exclude": ["homer"]}, f)
+        config = load_filter_config(path)
+        self.assertEqual(config["exclude"], ["homer"])
+
+    def test_missing_exclude_defaults_to_empty(self):
+        path = Path(self.tmpdir.name) / "filter.yml"
+        with open(path, "w") as f:
+            yaml.dump({"images": ["ara_server"]}, f)
+        config = load_filter_config(path)
+        self.assertEqual(config["exclude"], [])
+
+    def test_unmanaged_manager_key(self):
+        path = Path(self.tmpdir.name) / "filter.yml"
+        with open(path, "w") as f:
+            yaml.dump(
+                {
+                    "images": ["ara_server"],
+                    "unmanaged_manager": ["rsync:latest"],
+                },
+                f,
+            )
+        config = load_filter_config(path)
+        self.assertEqual(config["unmanaged_manager"], ["rsync:latest"])
+
+    def test_missing_unmanaged_manager_defaults_to_empty(self):
+        path = Path(self.tmpdir.name) / "filter.yml"
+        with open(path, "w") as f:
+            yaml.dump({"images": ["ara_server"]}, f)
+        config = load_filter_config(path)
+        self.assertEqual(config["unmanaged_manager"], [])
+
+
+class TestValidateFilter(unittest.TestCase):
+    def setUp(self):
+        self.image_mapping = {
+            "ara_server": "osism/ara-server",
+            "netbox": "osism/netbox",
+            "traefik": "traefik",
+        }
+        self.all_versions = {
+            "ara_server": {"1.0", "1.1"},
+            "netbox": {"v3.0"},
+            "traefik": {"v2.0"},
+        }
+
+    def test_valid_filter(self):
+        errors = validate_filter(
+            ["ara_server", "netbox", "traefik"],
+            self.image_mapping,
+            self.all_versions,
+        )
+        self.assertEqual(errors, [])
+
+    def test_unknown_upstream_image(self):
+        errors = validate_filter(
+            ["ara_server", "netbox"],
+            self.image_mapping,
+            self.all_versions,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("traefik", errors[0])
+        self.assertIn("not in the filter config", errors[0])
+
+    def test_stale_filter_entry(self):
+        errors = validate_filter(
+            ["ara_server", "netbox", "traefik", "old_image"],
+            self.image_mapping,
+            self.all_versions,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("old_image", errors[0])
+        self.assertIn("does not exist in", errors[0])
+
+    def test_image_in_mapping_but_no_versions_not_flagged(self):
+        # mariadb is in mapping but has no entry in all_versions
+        mapping = dict(self.image_mapping)
+        mapping["mariadb"] = "osism/mariadb"
+        errors = validate_filter(
+            ["ara_server", "netbox", "traefik"],
+            mapping,
+            self.all_versions,
+        )
+        # mariadb has no versions so it's not in upstream_with_versions, no error
+        self.assertEqual(errors, [])
+
+    def test_multiple_errors(self):
+        errors = validate_filter(
+            ["ara_server", "stale_one", "stale_two"],
+            self.image_mapping,
+            self.all_versions,
+        )
+        # netbox and traefik are unknown upstream
+        unknown_errors = [e for e in errors if "not in the filter config" in e]
+        stale_errors = [e for e in errors if "does not exist in" in e]
+        self.assertEqual(len(unknown_errors), 2)
+        self.assertEqual(len(stale_errors), 2)
+
+    def test_filter_entry_with_no_versions_is_error(self):
+        """Image in filter and in mapping but with no versions in any release."""
+        image_mapping = {"ara_server": "osism/ara-server",
+                         "netbox": "osism/netbox"}
+        all_versions = {"ara_server": {"1.0"}}  # netbox has no versions
+        errors = validate_filter(
+            ["ara_server", "netbox"],
+            image_mapping,
+            all_versions,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("netbox", errors[0])
+        self.assertIn("no versions", errors[0])
+
+    def test_excluded_images_not_flagged(self):
+        errors = validate_filter(
+            ["ara_server", "netbox"],
+            self.image_mapping,
+            self.all_versions,
+            exclude_names=["traefik"],
+        )
+        self.assertEqual(errors, [])
+
+    def test_excluded_but_not_in_mapping_still_ok(self):
+        """Excluding a name that doesn't exist in mapping is harmless."""
+        errors = validate_filter(
+            ["ara_server", "netbox", "traefik"],
+            self.image_mapping,
+            self.all_versions,
+            exclude_names=["nonexistent"],
+        )
+        self.assertEqual(errors, [])
+
+
+class TestGenerateImageEntries(unittest.TestCase):
+    def setUp(self):
+        self.image_mapping = {
+            "ara_server": "osism/ara-server",
+            "netbox": "osism/netbox",
+            "traefik": "traefik",
+            "redis": "osism/redis",
+        }
+        self.all_versions = {
+            "ara_server": {"1.0", "1.1"},
+            "netbox": {"v3.0"},
+            "traefik": {"v2.0", "v2.1"},
+            "redis": {"7.0"},
+        }
+
+    def test_prefix_split(self):
+        images, images_manager = generate_image_entries(
+            ["ara_server", "traefik"], self.image_mapping, self.all_versions, [], []
+        )
+        self.assertIn("traefik:v2.0", images)
+        self.assertIn("ara-server:1.0", images_manager)
+
+    def test_osism_prefix_stripped(self):
+        images, images_manager = generate_image_entries(
+            ["netbox"], self.image_mapping, self.all_versions, [], []
+        )
+        self.assertIn("netbox:v3.0", images_manager)
+        self.assertNotIn("osism/netbox:v3.0", images_manager)
+
+    def test_sorted_output(self):
+        images, images_manager = generate_image_entries(
+            ["ara_server", "netbox", "traefik", "redis"],
+            self.image_mapping,
+            self.all_versions,
+            [],
+            [],
+        )
+        self.assertEqual(images, sorted(images))
+        self.assertEqual(images_manager, sorted(images_manager))
+
+    def test_multiple_versions(self):
+        images, images_manager = generate_image_entries(
+            ["traefik"], self.image_mapping, self.all_versions, [], []
+        )
+        self.assertIn("traefik:v2.0", images)
+        self.assertIn("traefik:v2.1", images)
+
+    def test_unmanaged_passthrough(self):
+        unmanaged = ["library/httpd:alpine", "library/nginx:latest"]
+        images, images_manager = generate_image_entries(
+            [], self.image_mapping, self.all_versions, unmanaged, []
+        )
+        self.assertIn("library/httpd:alpine", images)
+        self.assertIn("library/nginx:latest", images)
+
+    def test_unmanaged_included_in_sorted_images(self):
+        unmanaged = ["zzz/image:latest"]
+        images, images_manager = generate_image_entries(
+            ["traefik"], self.image_mapping, self.all_versions, unmanaged, []
+        )
+        self.assertIn("zzz/image:latest", images)
+        self.assertEqual(images, sorted(images))
+
+    def test_name_not_in_all_versions_produces_no_entries(self):
+        all_versions = {}
+        images, images_manager = generate_image_entries(
+            ["ara_server"], self.image_mapping, all_versions, [], []
+        )
+        self.assertEqual(images, [])
+        self.assertEqual(images_manager, [])
+
+    def test_unmanaged_manager_goes_to_images_manager(self):
+        unmanaged_manager = ["rsync:latest", "osism-frontend:latest"]
+        images, images_manager = generate_image_entries(
+            [], self.image_mapping, self.all_versions, [], unmanaged_manager
+        )
+        self.assertIn("rsync:latest", images_manager)
+        self.assertIn("osism-frontend:latest", images_manager)
+        self.assertEqual(images, [])
+
+    def test_unmanaged_manager_sorted_with_generated(self):
+        unmanaged_manager = ["zzz:latest"]
+        images, images_manager = generate_image_entries(
+            ["ara_server"], self.image_mapping, self.all_versions, [], unmanaged_manager
+        )
+        self.assertIn("zzz:latest", images_manager)
+        self.assertEqual(images_manager, sorted(images_manager))
+
+    def test_keep_latest_for_collapses_to_latest(self):
+        all_versions = {
+            "ara_server": {"1.7.2", "1.7.3"},
+            "traefik": {"v2.0", "v2.1"},
+        }
+        # traefik is in keep_latest_for -> only :latest emitted
+        images, images_manager = generate_image_entries(
+            ["ara_server", "traefik"],
+            self.image_mapping,
+            all_versions,
+            [],
+            [],
+            keep_latest_for={"traefik"},
+        )
+        traefik_entries = [e for e in images if e.startswith("traefik:")]
+        self.assertEqual(traefik_entries, ["traefik:latest"])
+        # ara_server is NOT in keep_latest_for -> all versions preserved
+        ara_entries = [e for e in images_manager if e.startswith("ara-server:")]
+        self.assertEqual(sorted(ara_entries), ["ara-server:1.7.2", "ara-server:1.7.3"])
+
+    def test_keep_latest_for_osism_prefix(self):
+        """keep_latest_for uses short names (prefix stripped)."""
+        all_versions = {
+            "ara_server": {"1.7.2", "1.7.3"},
+        }
+        images, images_manager = generate_image_entries(
+            ["ara_server"],
+            self.image_mapping,
+            all_versions,
+            [],
+            [],
+            keep_latest_for={"ara-server"},
+        )
+        self.assertEqual(images_manager, ["ara-server:latest"])
+
+    def test_keep_latest_for_empty_expands_all(self):
+        all_versions = {
+            "traefik": {"v2.0", "v2.1"},
+        }
+        images, _ = generate_image_entries(
+            ["traefik"], self.image_mapping, all_versions, [], [], keep_latest_for=set()
+        )
+        self.assertIn("traefik:v2.0", images)
+        self.assertIn("traefik:v2.1", images)
+        self.assertNotIn("traefik:latest", images)
+
+
+class TestCollectLatestImages(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _write_zuul(self, data):
+        path = Path(self.tmpdir.name) / "container-images.yml"
+        with open(path, "w") as f:
+            f.write("---\n")
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+        return str(path)
+
+    def test_finds_latest_in_both_lists(self):
+        path = self._write_zuul(
+            {
+                "images": ["library/httpd:alpine", "osism:latest"],
+                "images_manager": ["ara-server:1.7.3", "tempest:latest"],
+            }
+        )
+        result = _collect_latest_images(path)
+        self.assertEqual(result, {"osism", "tempest"})
+
+    def test_no_latest_returns_empty(self):
+        path = self._write_zuul(
+            {
+                "images": ["library/httpd:alpine"],
+                "images_manager": ["ara-server:1.7.3"],
+            }
+        )
+        result = _collect_latest_images(path)
+        self.assertEqual(result, set())
+
+    def test_handles_missing_lists(self):
+        path = self._write_zuul({})
+        result = _collect_latest_images(path)
+        self.assertEqual(result, set())
+
+
+class TestUpdateZuulFile(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _write_zuul_file(self, data):
+        path = Path(self.tmpdir.name) / "container-images.yml"
+        with open(path, "w") as f:
+            f.write("---\n")
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+        return path
+
+    def test_preserves_other_keys(self):
+        path = self._write_zuul_file(
+            {
+                "images": ["old:1.0"],
+                "images_manager": ["old-mgr:1.0"],
+                "extra_key": "keep_me",
+            }
+        )
+        update_zuul_file(path, ["new:2.0"], ["new-mgr:2.0"])
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        self.assertEqual(data["extra_key"], "keep_me")
+        self.assertEqual(data["images"], ["new:2.0"])
+        self.assertEqual(data["images_manager"], ["new-mgr:2.0"])
+
+    def test_output_starts_with_yaml_document_marker(self):
+        path = self._write_zuul_file({"images": [], "images_manager": []})
+        update_zuul_file(path, [], [])
+        with open(path) as f:
+            content = f.read()
+        self.assertTrue(content.startswith("---\n"))
+
+    def test_updates_images_list(self):
+        path = self._write_zuul_file({"images": ["old:1.0"], "images_manager": []})
+        update_zuul_file(path, ["a:1.0", "b:2.0"], [])
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        self.assertEqual(data["images"], ["a:1.0", "b:2.0"])
+
+    def test_updates_images_manager_list(self):
+        path = self._write_zuul_file({"images": [], "images_manager": ["old-mgr:1.0"]})
+        update_zuul_file(path, [], ["mgr-a:1.0", "mgr-b:2.0"])
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        self.assertEqual(data["images_manager"], ["mgr-a:1.0", "mgr-b:2.0"])
+
+    def test_empty_list_written_as_empty_yaml_list(self):
+        path = self._write_zuul_file({
+            "images": ["old:1.0"],
+            "images_manager": ["old-mgr:1.0"],
+            "images_kolla_metalbox": [],
+        })
+        update_zuul_file(path, [], [])
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        self.assertEqual(data["images"], [])
+        self.assertEqual(data["images_manager"], [])
+        self.assertEqual(data["images_kolla_metalbox"], [])
+
+
+class TestDetectLatestMajor(unittest.TestCase):
+    def test_picks_highest(self):
+        versions = ["7.0.0", "7.1.0", "9.0.0", "9.1.0", "10.0.0"]
+        self.assertEqual(detect_latest_major(versions), 10)
+
+    def test_single_version(self):
+        self.assertEqual(detect_latest_major(["5.0.0"]), 5)
+
+
+class TestEndToEnd(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.release_dir = os.path.join(self.tmpdir, "release")
+        self.metalbox_dir = os.path.join(self.tmpdir, "metalbox")
+
+        # Build a minimal release repo
+        os.makedirs(os.path.join(self.release_dir, "etc"))
+        with open(os.path.join(self.release_dir, "etc", "images.yml"), "w") as f:
+            yaml.dump(
+                {
+                    "ara_server": "osism/ara-server",
+                    "vault": "hashicorp/vault",
+                    "redis": "library/redis",
+                    "homer": "osism/homer",
+                },
+                f,
+            )
+
+        for version, images in [
+            (
+                "9.0.0",
+                {
+                    "ara_server": "1.7.2",
+                    "vault": "1.19.1",
+                    "redis": "7.4.2-alpine",
+                    "homer": "v25.04.1",
+                },
+            ),
+            (
+                "9.1.0",
+                {
+                    "ara_server": "1.7.2",
+                    "vault": "1.19.5",
+                    "redis": "7.4.4-alpine",
+                    "homer": "v25.05.2",
+                },
+            ),
+            (
+                "9.3.0",
+                {
+                    "ara_server": "1.7.3",
+                    "vault": "1.19.5",
+                    "redis": "7.4.4-alpine",
+                    "homer": "v25.08.1",
+                },
+            ),
+        ]:
+            v_dir = os.path.join(self.release_dir, version)
+            os.makedirs(v_dir)
+            with open(os.path.join(v_dir, "base.yml"), "w") as f:
+                yaml.dump({"docker_images": images}, f)
+
+        # Build minimal metalbox structure
+        scripts_dir = os.path.join(self.metalbox_dir, "scripts")
+        zuul_dir = os.path.join(self.metalbox_dir, "zuul", "vars")
+        os.makedirs(scripts_dir)
+        os.makedirs(zuul_dir)
+
+        # Filter config -- deliberately omit homer to test error
+        with open(os.path.join(scripts_dir, "metalbox-images.yml"), "w") as f:
+            yaml.dump(
+                {
+                    "images": ["ara_server", "vault", "redis"],
+                    "unmanaged": ["library/httpd:alpine"],
+                },
+                f,
+            )
+
+        # Existing zuul file
+        with open(os.path.join(zuul_dir, "container-images.yml"), "w") as f:
+            yaml.dump(
+                {
+                    "images": ["old:1.0"],
+                    "images_manager": ["old-mgr:1.0"],
+                    "images_kolla_metalbox": ["cron:2024.2", "ironic-api:2024.2"],
+                },
+                f,
+            )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_error_on_unknown_upstream_image(self):
+        """homer is in release but not in filter -> error."""
+        ret = run(
+            release_repo=self.release_dir,
+            major=9,
+            filter_path=os.path.join(
+                self.metalbox_dir, "scripts", "metalbox-images.yml"
+            ),
+            zuul_path=os.path.join(
+                self.metalbox_dir, "zuul", "vars", "container-images.yml"
+            ),
+        )
+        self.assertEqual(ret, 1)
+
+    def test_success_when_filter_is_complete(self):
+        """Add homer to filter -> success."""
+        filter_path = os.path.join(self.metalbox_dir, "scripts", "metalbox-images.yml")
+        with open(filter_path, "w") as f:
+            yaml.dump(
+                {
+                    "images": ["ara_server", "homer", "vault", "redis"],
+                    "unmanaged": ["library/httpd:alpine"],
+                },
+                f,
+            )
+
+        zuul_path = os.path.join(
+            self.metalbox_dir, "zuul", "vars", "container-images.yml"
+        )
+        ret = run(
+            release_repo=self.release_dir,
+            major=9,
+            filter_path=filter_path,
+            zuul_path=zuul_path,
+        )
+        self.assertEqual(ret, 0)
+
+        with open(zuul_path) as f:
+            result = yaml.safe_load(f)
+
+        # Check images (non-osism)
+        self.assertIn("hashicorp/vault:1.19.1", result["images"])
+        self.assertIn("hashicorp/vault:1.19.5", result["images"])
+        self.assertIn("library/redis:7.4.2-alpine", result["images"])
+        self.assertIn("library/redis:7.4.4-alpine", result["images"])
+        self.assertIn("library/httpd:alpine", result["images"])
+
+        # Check images_manager (osism, prefix stripped)
+        self.assertIn("ara-server:1.7.2", result["images_manager"])
+        self.assertIn("ara-server:1.7.3", result["images_manager"])
+        self.assertIn("homer:v25.04.1", result["images_manager"])
+
+        # Kolla preserved
+        self.assertEqual(
+            result["images_kolla_metalbox"],
+            ["cron:2024.2", "ironic-api:2024.2"],
+        )
+
+    def test_keep_latest_preserves_existing_tags(self):
+        """--keep-latest reads existing zuul file and preserves :latest."""
+        filter_path = os.path.join(self.metalbox_dir, "scripts", "metalbox-images.yml")
+        with open(filter_path, "w") as f:
+            yaml.dump(
+                {
+                    "images": ["ara_server", "homer", "vault", "redis"],
+                    "unmanaged": ["library/httpd:alpine"],
+                },
+                f,
+            )
+
+        zuul_path = os.path.join(
+            self.metalbox_dir, "zuul", "vars", "container-images.yml"
+        )
+        # Write existing zuul file with vault:latest
+        with open(zuul_path, "w") as f:
+            f.write("---\n")
+            yaml.dump(
+                {
+                    "images": ["hashicorp/vault:latest", "library/httpd:alpine"],
+                    "images_manager": ["ara-server:1.7.2"],
+                    "images_kolla_metalbox": [],
+                },
+                f,
+                default_flow_style=False,
+                sort_keys=False,
+            )
+
+        ret = run(
+            release_repo=self.release_dir,
+            major=9,
+            filter_path=filter_path,
+            zuul_path=zuul_path,
+            keep_latest=True,
+        )
+        self.assertEqual(ret, 0)
+
+        with open(zuul_path) as f:
+            result = yaml.safe_load(f)
+
+        # vault had :latest in existing file -> preserved
+        vault_entries = [
+            e for e in result["images"] if e.startswith("hashicorp/vault:")
+        ]
+        self.assertEqual(vault_entries, ["hashicorp/vault:latest"])
+        # ara-server did NOT have :latest -> expanded
+        ara_entries = [
+            e for e in result["images_manager"] if e.startswith("ara-server:")
+        ]
+        self.assertIn("ara-server:1.7.2", ara_entries)
+        self.assertIn("ara-server:1.7.3", ara_entries)
+
+    def test_unmanaged_manager_in_end_to_end(self):
+        """unmanaged_manager entries go to images_manager."""
+        filter_path = os.path.join(self.metalbox_dir, "scripts", "metalbox-images.yml")
+        with open(filter_path, "w") as f:
+            yaml.dump(
+                {
+                    "images": ["ara_server", "homer", "vault", "redis"],
+                    "unmanaged": ["library/httpd:alpine"],
+                    "unmanaged_manager": ["rsync:latest"],
+                },
+                f,
+            )
+
+        zuul_path = os.path.join(
+            self.metalbox_dir, "zuul", "vars", "container-images.yml"
+        )
+        ret = run(
+            release_repo=self.release_dir,
+            major=9,
+            filter_path=filter_path,
+            zuul_path=zuul_path,
+        )
+        self.assertEqual(ret, 0)
+
+        with open(zuul_path) as f:
+            result = yaml.safe_load(f)
+
+        self.assertIn("rsync:latest", result["images_manager"])
+        self.assertNotIn("rsync:latest", result["images"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The images and images_manager sections of
zuul/vars/container-images.yml are maintained manually. When a new OSISM release bumps an image version, someone must add the new tag by hand. This is error-prone and leads to drift (e.g. the current file targets ~9.5.0 but has vault stuck at 9.1.0).

Add scripts/generate_image_list.py which generates these sections from the osism/release repository. It computes the union of all image versions across a major release series so the mirror can serve sites on any minor release.

Usage:

  python3 scripts/generate_image_list.py \
    [--major N] [--release-repo PATH] [--keep-latest]

By default the tool fetches from GitHub and targets the latest non-RC major release. --release-repo overrides with a local checkout. --keep-latest preserves existing :latest tags from the zuul file instead of expanding them to pinned versions.

Which images the Metalbox mirrors is controlled by scripts/metalbox-images.yml, which lists images to include, images to explicitly exclude, and unmanaged images not tracked by the release repo. The script errors when new images appear upstream that are not accounted for in this filter file.

Includes 61 unit and end-to-end tests.

AI-assisted: Claude Code