### PR TITLE
zuul: verify bzip2 archive integrity before upload

### DIFF
--- a/zuul/mirror-container-images.yml
+++ b/zuul/mirror-container-images.yml
@@ -111,6 +111,12 @@
         command: "sh -c 'cd /volume && tar cjf /export/{{ _tarball_name }} .'"
       when: _publish | bool
 
+    - name: Verify bzip2 archive integrity
+      ansible.builtin.command:
+        cmd: "bzip2 -t {{ _tarball_name }}"
+      when: _publish | bool
+      changed_when: false
+
     - name: Get size of export archive
       ansible.builtin.stat:
         path: "{{ _tarball_name }}"

--- a/zuul/mirror-debian-packages.yml
+++ b/zuul/mirror-debian-packages.yml
@@ -41,6 +41,13 @@
       when: _publish | default(false) | bool
       changed_when: true
 
+    - name: Verify bzip2 archive integrity
+      ansible.builtin.command:
+        chdir: "{{ zuul.project.src_dir | default('.') }}"
+        cmd: bzip2 -t ubuntu-noble.tar.bz2
+      when: _publish | default(false) | bool
+      changed_when: false
+
 
     - name: Install rclone
       become: true


### PR DESCRIPTION
Run bzip2 -t on generated archives in the mirror-debian-packages and mirror-container-images jobs so that a corrupt archive fails the job before it is published to S3.