### PR TITLE
zuul: generate, upload, and print SHA256 checksum in mirror jobs

### DIFF
--- a/zuul/mirror-container-images.yml
+++ b/zuul/mirror-container-images.yml
@@ -117,6 +117,25 @@
       when: _publish | bool
       changed_when: false
 
+    - name: Generate SHA256 checksum
+      ansible.builtin.command:
+        cmd: "sha256sum {{ _tarball_name }}"
+      register: _sha256_result
+      when: _publish | bool
+      changed_when: false
+
+    - name: Write SHA256 checksum file
+      ansible.builtin.copy:
+        content: "{{ _sha256_result.stdout }}\n"
+        dest: "{{ _tarball_name }}.CHECKSUM"
+        mode: "0644"
+      when: _publish | bool
+
+    - name: Print SHA256 checksum
+      ansible.builtin.debug:
+        msg: "{{ _sha256_result.stdout }}"
+      when: _publish | bool
+
     - name: Get size of export archive
       ansible.builtin.stat:
         path: "{{ _tarball_name }}"
@@ -142,7 +161,6 @@
       ansible.builtin.shell:  # noqa command-instead-of-module
         executable: /bin/bash
         cmd: |
-          sha256sum {{ _tarball_name }} > {{ _tarball_name }}.CHECKSUM
           rclone copyto {{ _tarball_name }}.CHECKSUM s3:osism/metalbox/{{ _tarball_name }}.CHECKSUM
           rclone copyto {{ _tarball_name }} s3:osism/metalbox/{{ _tarball_name }}
       environment:

--- a/zuul/mirror-debian-packages.yml
+++ b/zuul/mirror-debian-packages.yml
@@ -37,7 +37,6 @@
           version=$(date +%Y%m%d)
           docker tag "quay.io/osism-mirror/ubuntu-noble:$version" registry.osism.tech/osism/packages/ubuntu-noble:latest
           docker save registry.osism.tech/osism/packages/ubuntu-noble:latest | bzip2 > ubuntu-noble.tar.bz2
-          sha256sum ubuntu-noble.tar.bz2 > ubuntu-noble.tar.bz2.CHECKSUM
       when: _publish | default(false) | bool
       changed_when: true
 
@@ -48,6 +47,25 @@
       when: _publish | default(false) | bool
       changed_when: false
 
+    - name: Generate SHA256 checksum
+      ansible.builtin.command:
+        chdir: "{{ zuul.project.src_dir | default('.') }}"
+        cmd: sha256sum ubuntu-noble.tar.bz2
+      register: _sha256_result
+      when: _publish | default(false) | bool
+      changed_when: false
+
+    - name: Write SHA256 checksum file
+      ansible.builtin.copy:
+        content: "{{ _sha256_result.stdout }}\n"
+        dest: "{{ zuul.project.src_dir | default('.') }}/ubuntu-noble.tar.bz2.CHECKSUM"
+        mode: "0644"
+      when: _publish | default(false) | bool
+
+    - name: Print SHA256 checksum
+      ansible.builtin.debug:
+        msg: "{{ _sha256_result.stdout }}"
+      when: _publish | default(false) | bool
 
     - name: Install rclone
       become: true


### PR DESCRIPTION
Move sha256sum generation out of the upload/export steps into a dedicated task next to the bzip2 integrity check, write the .CHECKSUM file from its output, and print the checksum via debug so it appears in the job log.

AI-assisted: Claude Code