### PR TITLE
fix octavia-import.sh

### DIFF
--- a/scripts/octavia-export.sh
+++ b/scripts/octavia-export.sh
@@ -15,7 +15,7 @@ OCTAVIA_EXPORT_SIZE="${OCTAVIA_EXPORT_SIZE:-1G}"
 # Check if version parameter is provided
 if [[ -z "$1" ]]; then
     echo -e "${RED}Error: OpenStack version parameter required${NC}"
-    echo -e "Usage: $0 <version> (e.g., $0 2024.2)"
+    echo -e "Usage: $0 <version> (e.g., $0 2025.1)"
     exit 1
 fi
 

--- a/scripts/octavia-import.sh
+++ b/scripts/octavia-import.sh
@@ -10,7 +10,7 @@ NC='\033[0m' # No Color
 
 # Default patterns or use environment variables
 OCTAVIA_METADATA_PATTERN="${OCTAVIA_METADATA_PATTERN:-last-*}"
-OCTAVIA_IMAGE_PATTERN="${OCTAVIA_IMAGE_PATTERN:-octavia-amphora-haproxy-*.qcow2}"
+OCTAVIA_IMAGE_PATTERN="${OCTAVIA_IMAGE_PATTERN:-octavia-amphora-haproxy-*.qcow2*}"
 # Default destination directory or use environment variable
 OCTAVIA_DEST_DIR="${OCTAVIA_DEST_DIR:-/opt/httpd/data/root/octavia}"
 


### PR DESCRIPTION
The import was missing the checksum file(s), amend the image pattern to include these.

Also amend the usage note to reference an octavia version that is still active.