### PR TITLE
Select valkey over redis from 2025.2

### DIFF
--- a/scripts/deploy-infrastructure.sh
+++ b/scripts/deploy-infrastructure.sh
@@ -18,8 +18,11 @@ else
     echo "httpd container is already running"
 fi
 
+source /opt/configuration/scripts/include.sh
+key_value_store=$(valkey_or_redis)
+
 osism apply common
-osism apply redis
+osism apply "$key_value_store"
 osism apply memcached
 osism apply rabbitmq
 osism apply mariadb

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -1,0 +1,11 @@
+# Select the key-value store service for the active OpenStack release. Upstream
+# kolla-ansible replaced redis with valkey at 2025.2; older releases still ship
+# redis. The release is read from the kolla-ansible image label.
+valkey_or_redis() {
+    local openstack_version
+    openstack_version=$(docker inspect --format '{{ index .Config.Labels "de.osism.release.openstack" }}' kolla-ansible 2>/dev/null)
+    case "$openstack_version" in
+        2023.*|2024.*|2025.1) echo redis ;;
+        *) echo valkey ;;
+    esac
+}

--- a/scripts/run-all.sh
+++ b/scripts/run-all.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source /opt/configuration/scripts/include.sh
+
 MANAGED_SITE="$1"
 ENABLE_SONIC="${ENABLE_SONIC:-true}"
 
@@ -29,8 +31,9 @@ osism sync inventory
 osism apply hosts
 osism apply network
 osism apply facts
+key_value_store=$(valkey_or_redis)
 osism apply common
-osism apply redis
+osism apply "$key_value_store"
 osism apply memcached
 osism apply rabbitmq
 osism apply mariadb

--- a/scripts/update-infrastructure.sh
+++ b/scripts/update-infrastructure.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 
+source /opt/configuration/scripts/include.sh
+key_value_store=$(valkey_or_redis)
+
 osism apply -a pull common
-osism apply -a pull redis
+osism apply -a pull "$key_value_store"
 osism apply -a pull memcached
 osism apply -a pull rabbitmq
 osism apply -a pull mariadb
 
 osism apply -a upgrade common
-osism apply -a upgrade redis
+osism apply -a upgrade "$key_value_store"
 osism apply -a upgrade memcached
 osism apply -a upgrade rabbitmq
 osism apply -a upgrade mariadb


### PR DESCRIPTION
Part of the OSISM-wide **redis → valkey** migration (upstream kolla-ansible
replaced redis with valkey at `stable/2025.2`; the redis role/playbook is gone).

Picks the key-value store per OpenStack release (redis for 2024.x/2025.1, valkey
for 2025.2 and newer) so `osism apply`/`upgrade` targets the service the active
image actually ships. On upgrade to 2025.2, the valkey role's upgrade tasks
migrate the redis data and remove the old redis containers automatically — no
manual teardown.

**Draft:** the OSISM defaults switch-over and these consumer-script changes must
land together, gated on the release `defaults_version` pin bump — held as draft
until that coordinated landing.


Part of the redis → valkey migration (all must land together, gated on the
release `defaults_version` pin bump):

- osism/defaults#292
- osism/testbed#2918
- osism/container-image-kolla-ansible#925
- osism/metalbox#368
- osism/cloud-in-a-box#445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
