### PR TITLE
mirror: upload artifacts before their checksums

### DIFF
--- a/zuul/mirror-container-images.yml
+++ b/zuul/mirror-container-images.yml
@@ -161,8 +161,15 @@
       ansible.builtin.shell:  # noqa command-instead-of-module
         executable: /bin/bash
         cmd: |
-          rclone copyto {{ _tarball_name }}.CHECKSUM s3:osism/metalbox/{{ _tarball_name }}.CHECKSUM
+          set -e
+
+          # Upload the tarball before the checksum that describes it, so the
+          # published pair is inconsistent only for the small object and a
+          # failed tarball upload leaves the previous pair intact. set -e is
+          # what makes the order meaningful: without it the checksum would be
+          # published even when the tarball upload failed.
           rclone copyto {{ _tarball_name }} s3:osism/metalbox/{{ _tarball_name }}
+          rclone copyto {{ _tarball_name }}.CHECKSUM s3:osism/metalbox/{{ _tarball_name }}.CHECKSUM
       environment:
         RCLONE_CONFIG_S3_TYPE: s3
         RCLONE_CONFIG_S3_PROVIDER: Ceph

--- a/zuul/mirror-debian-packages.yml
+++ b/zuul/mirror-debian-packages.yml
@@ -87,8 +87,13 @@
           version=$(date +%Y%m%d)
           docker push "quay.io/osism-mirror/ubuntu-noble:$version"
 
-          rclone copyto ubuntu-noble.tar.bz2.CHECKSUM s3:osism/metalbox/ubuntu-noble.tar.bz2.CHECKSUM
+          # Upload the tarball before the checksum that describes it. Both
+          # objects have fixed names, so the pair is briefly inconsistent
+          # either way, but this order keeps that window to one small object
+          # instead of the whole tarball transfer, and a failed tarball upload
+          # then leaves the previous artifact and its checksum both intact.
           rclone copyto ubuntu-noble.tar.bz2 s3:osism/metalbox/ubuntu-noble.tar.bz2
+          rclone copyto ubuntu-noble.tar.bz2.CHECKSUM s3:osism/metalbox/ubuntu-noble.tar.bz2.CHECKSUM
       environment:
         RCLONE_CONFIG_S3_TYPE: s3
         RCLONE_CONFIG_S3_PROVIDER: Ceph

--- a/zuul/mirror-octavia-image.yml
+++ b/zuul/mirror-octavia-image.yml
@@ -40,8 +40,11 @@
 
           sha256sum octavia-export-{{ item }}.img > octavia-export-{{ item }}.img.CHECKSUM
 
-          rclone copyto octavia-export-{{ item }}.img.CHECKSUM s3:osism/metalbox/octavia-export-{{ item }}.img.CHECKSUM
+          # Upload the image before the checksum that describes it, so the
+          # published pair is inconsistent only for the small object and a
+          # failed image upload leaves the previous pair intact.
           rclone copyto octavia-export-{{ item }}.img s3:osism/metalbox/octavia-export-{{ item }}.img
+          rclone copyto octavia-export-{{ item }}.img.CHECKSUM s3:osism/metalbox/octavia-export-{{ item }}.img.CHECKSUM
       environment:
         RCLONE_CONFIG_S3_TYPE: s3
         RCLONE_CONFIG_S3_PROVIDER: Ceph


### PR DESCRIPTION
Part of:

- osism/metalbox#375

---

The three publish playbooks uploaded the .CHECKSUM file before the
artifact it describes. Both objects have fixed names in the S3 bucket
and no history, and the two uploads are separate PUTs with nothing
tying them together, so the published pair is inconsistent for the
duration of whichever upload runs second.

Putting the checksum first makes that window the entire large transfer,
on every run: for ubuntu-noble.tar.bz2 on 2026-08-02 the checksum
landed at 01:10:25 and the 5.53 GB tarball at 01:16:20, so for six
minutes the published checksum described an object that was not there
yet. Worse, if the artifact upload fails the mismatch is permanent
until the next successful run: the previous artifact is still intact
and still good, but the checksum no longer describes it, so a consumer
that verifies must reject it. A failed publish took the fallback down
with it, which defeats the point of leaving the previous artifact in
place.

Upload the artifact first and the checksum last. The routine
inconsistency window shrinks from the large transfer to one small
object, and a failed artifact upload now leaves the previous artifact
and its matching checksum both in place.

mirror-container-images.yml had no `set -e` in its upload block, so the
second rclone ran even when the first had failed. The ordering only
means anything if a failed artifact upload aborts before the checksum
is published, so add it there.

This does not make publishing atomic -- two objects cannot be updated
together, and a consumer can still observe a mismatch, so verifying the
checksum before use remains necessary. Giving the S3 objects
date-stamped names plus a small pointer file, matching the history the
quay.io/osism-mirror tags already have, would be the durable fix.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Roger Luethi <luethi@osism.tech>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
