### PR TITLE
mirror: fix correctness defects in create-mirror.sh

### DIFF
--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -1070,7 +1070,16 @@ download_direct_urls() {
 
     if [[ ${#direct_urls[@]} -gt 0 ]]; then
         log "Downloading ${#direct_urls[@]} direct URLs..."
-        parallel_download_files "$download_dir" "${direct_urls[@]}"
+
+        # parallel_download_files returns the number of files still missing.
+        # Left as the function's exit status it would abort the whole script
+        # through set -e, with that count as the exit code and nothing logged.
+        local direct_failed=0
+        parallel_download_files "$download_dir" "${direct_urls[@]}" || direct_failed=$?
+
+        if [[ $direct_failed -gt 0 ]]; then
+            error "$direct_failed of ${#direct_urls[@]} direct URLs could not be downloaded"
+        fi
     fi
 }
 

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -1082,8 +1082,14 @@ resolve_dependencies_from_file() {
     ')
 
     if [[ -n "$deps" ]]; then
-        # Split dependencies and clean up
-        echo "$deps" | tr ',' '\n' | sed 's/^[ \t]*//;s/[ \t]*$//' | grep -v '^$'
+        # Split dependencies and clean up. Multiarch qualifiers (perl:any,
+        # python3:any, foo:native) are part of the dependency syntax, not of
+        # the package name, and no Packages file has a stanza for the
+        # qualified form -- strip them or the dependency is reported as not
+        # found in any repository.
+        echo "$deps" | tr ',' '\n' \
+            | sed -e 's/^[ \t]*//;s/[ \t]*$//' -e 's/:\(any\|native\)$//' \
+            | grep -v '^$'
     fi
 }
 

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -37,6 +37,10 @@ RETRY_BACKOFF_SECONDS="${RETRY_BACKOFF_SECONDS:-15}"
 
 # Performance optimizations
 PACKAGES_CACHE_DIR="$TEMP_DIR/packages_cache"
+# Expected checksums harvested from the repository indexes, as
+# "filename<TAB>sha256<TAB>size" records. Written while resolving package URLs
+# and consulted after each download.
+PACKAGES_CHECKSUM_FILE="$TEMP_DIR/expected_checksums.tsv"
 declare -A PACKAGES_METADATA_CACHE
 
 # Colors for output
@@ -148,6 +152,71 @@ download_file() {
     fi
 }
 
+# Record the expected checksum of a package file, as advertised by the
+# repository index it was resolved from.
+record_package_checksum() {
+    local filename="$1"
+    local sha256="$2"
+    local size="$3"
+
+    if [[ -z "$filename" || -z "$sha256" || -z "${PACKAGES_CHECKSUM_FILE:-}" ]]; then
+        return 0
+    fi
+
+    printf '%s\t%s\t%s\n' "$filename" "$sha256" "$size" >> "$PACKAGES_CHECKSUM_FILE"
+}
+
+# Verify a downloaded file. Prefers the SHA256 and Size advertised by the
+# repository index; falls back to a structural check for files downloaded
+# from a direct URL, which have no index metadata. Prints the reason and
+# returns non-zero when the file must be discarded.
+verify_downloaded_file() {
+    local path="$1"
+    local filename
+    filename=$(basename "$path")
+
+    local expected_sha256=""
+    local expected_size=""
+
+    if [[ -n "${PACKAGES_CHECKSUM_FILE:-}" && -f "$PACKAGES_CHECKSUM_FILE" ]]; then
+        local record
+        record=$(awk -F'\t' -v f="$filename" '$1 == f { print; exit }' "$PACKAGES_CHECKSUM_FILE" 2>/dev/null)
+        if [[ -n "$record" ]]; then
+            IFS=$'\t' read -r _ expected_sha256 expected_size <<< "$record"
+        fi
+    fi
+
+    if [[ -n "$expected_size" ]]; then
+        local actual_size
+        actual_size=$(stat -c%s "$path" 2>/dev/null)
+        if [[ "$actual_size" != "$expected_size" ]]; then
+            echo "size $actual_size, expected $expected_size"
+            return 1
+        fi
+    fi
+
+    if [[ -n "$expected_sha256" ]]; then
+        local actual_sha256
+        actual_sha256=$(sha256sum "$path" 2>/dev/null | cut -d' ' -f1)
+        if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+            echo "sha256 mismatch"
+            return 1
+        fi
+        return 0
+    fi
+
+    # No index metadata for this file. Make sure it is at least a readable
+    # Debian archive, which is what dpkg-scanpackages will demand later.
+    if [[ "$filename" == *.deb ]] && command -v dpkg-deb >/dev/null 2>&1; then
+        if ! dpkg-deb --info "$path" >/dev/null 2>&1; then
+            echo "not a readable Debian archive"
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
 # Build Packages index URL for a repository
 # For flat repos (component="flat"), the Packages file is at $base_url/$dist/Packages.gz
 # For standard repos, it's at $base_url/dists/$dist/$component/binary-$arch/Packages.gz
@@ -220,6 +289,17 @@ parallel_download_single() {
 
     if download_file "$url" "$output"; then
         if [[ -f "$output" && -s "$output" ]]; then
+            # A transfer that ends early still exits 0 in some cases (for
+            # example a chunked response truncated by the server), so the
+            # content has to be checked, not just its presence.
+            local verify_reason=""
+            if ! verify_reason=$(verify_downloaded_file "$output"); then
+                echo "        - Failed (corrupt): $filename ($verify_reason)" >&2
+                echo "FAILED: $filename (corrupt: $verify_reason)" >> "$temp_log"
+                rm -f "$output"
+                return 1
+            fi
+
             if [[ "$is_large_file" == "true" ]]; then
                 echo "        + Downloaded: $filename" >&2
             else
@@ -299,8 +379,8 @@ parallel_download_files() {
         done
 
         # Process downloads within this batch sequentially, but with parallel downloads within the batch
-        export -f parallel_download_single download_file
-        export TEMP_DIR
+        export -f parallel_download_single download_file verify_downloaded_file
+        export TEMP_DIR PACKAGES_CHECKSUM_FILE
 
         if [[ -s "$url_list" ]]; then
             local urls_in_batch=$(wc -l < "$url_list")
@@ -488,8 +568,8 @@ parallel_package_lookups() {
     printf '%s\n' "${packages[@]}" > "$package_list"
 
     # Export functions and variables needed by subprocesses
-    export -f parallel_package_lookup find_best_package find_package_info find_all_package_versions find_latest_netbird_version version_compare download_file cache_packages_file build_packages_url
-    export TEMP_DIR PACKAGES_CACHE_DIR
+    export -f parallel_package_lookup find_best_package find_package_info find_all_package_versions find_latest_netbird_version version_compare download_file cache_packages_file build_packages_url record_package_checksum
+    export TEMP_DIR PACKAGES_CACHE_DIR PACKAGES_CHECKSUM_FILE
     export -A PACKAGES_METADATA_CACHE
 
     # Use xargs for package lookups (GNU parallel disabled due to argument parsing issues)
@@ -618,6 +698,8 @@ find_package_info() {
             filename = ""
             version = ""
             pkg_arch = ""
+            sha256 = ""
+            size = ""
             for (i=1; i<=NF; i++) {
                 if ($i ~ /^Filename: /) {
                     filename = substr($i, 11)
@@ -628,9 +710,15 @@ find_package_info() {
                 if ($i ~ /^Architecture: /) {
                     pkg_arch = substr($i, 15)
                 }
+                if ($i ~ /^SHA256: /) {
+                    sha256 = substr($i, 9)
+                }
+                if ($i ~ /^Size: /) {
+                    size = substr($i, 7)
+                }
             }
             if (filename != "" && version != "" && (pkg_arch == arch || pkg_arch == "all")) {
-                print version "|" filename
+                print version "|" filename "|" sha256 "|" size
             }
         }
     ' | sort -t'|' -k1,1V | tail -1)
@@ -638,6 +726,9 @@ find_package_info() {
     if [[ -n "$package_info" ]]; then
         local version=$(echo "$package_info" | cut -d'|' -f1)
         local filename=$(echo "$package_info" | cut -d'|' -f2)
+        record_package_checksum "$(basename "$filename")" \
+            "$(echo "$package_info" | cut -d'|' -f3)" \
+            "$(echo "$package_info" | cut -d'|' -f4)"
         local result="$version|$base_url/$filename"
 
         # Cache the result
@@ -698,6 +789,8 @@ find_latest_netbird_version() {
                         filename = ""
                         version = ""
                         pkg_arch = ""
+                        sha256 = ""
+                        size = ""
                         for (i=1; i<=NF; i++) {
                             if ($i ~ /^Filename: /) {
                                 filename = substr($i, 11)
@@ -708,9 +801,15 @@ find_latest_netbird_version() {
                             if ($i ~ /^Architecture: /) {
                                 pkg_arch = substr($i, 15)
                             }
+                            if ($i ~ /^SHA256: /) {
+                                sha256 = substr($i, 9)
+                            }
+                            if ($i ~ /^Size: /) {
+                                size = substr($i, 7)
+                            }
                         }
                         if (filename != "" && version != "" && (pkg_arch == target_arch || pkg_arch == "all")) {
-                            print version "|" filename
+                            print version "|" filename "|" sha256 "|" size
                         }
                     }
                 ')
@@ -725,6 +824,9 @@ find_latest_netbird_version() {
                             if [[ -z "$latest_version" ]] || [[ $(version_compare "$version" "$latest_version") -eq 1 ]]; then
                                 latest_version="$version"
                                 latest_url="$base_url/$filename"
+                                record_package_checksum "$(basename "$filename")" \
+                                    "$(echo "$package_info" | cut -d'|' -f3)" \
+                                    "$(echo "$package_info" | cut -d'|' -f4)"
                             fi
                         fi
                     done <<< "$package_infos"
@@ -771,6 +873,8 @@ find_all_package_versions() {
                         filename = ""
                         version = ""
                         pkg_arch = ""
+                        sha256 = ""
+                        size = ""
                         for (i=1; i<=NF; i++) {
                             if ($i ~ /^Filename: /) {
                                 filename = substr($i, 11)
@@ -781,9 +885,15 @@ find_all_package_versions() {
                             if ($i ~ /^Architecture: /) {
                                 pkg_arch = substr($i, 15)
                             }
+                            if ($i ~ /^SHA256: /) {
+                                sha256 = substr($i, 9)
+                            }
+                            if ($i ~ /^Size: /) {
+                                size = substr($i, 7)
+                            }
                         }
                         if (filename != "" && version != "" && (pkg_arch == target_arch || pkg_arch == "all")) {
-                            print version "|" filename
+                            print version "|" filename "|" sha256 "|" size
                         }
                     }
                 ')
@@ -793,6 +903,9 @@ find_all_package_versions() {
                         if [[ -n "$package_info" ]]; then
                             local filename=$(echo "$package_info" | cut -d'|' -f2)
                             all_urls+=("$base_url/$filename")
+                            record_package_checksum "$(basename "$filename")" \
+                                "$(echo "$package_info" | cut -d'|' -f3)" \
+                                "$(echo "$package_info" | cut -d'|' -f4)"
                         fi
                     done <<< "$package_infos"
                 fi

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -1203,7 +1203,7 @@ download_packages() {
 
         # Remove duplicates
         if [[ ${#packages_to_download[@]} -gt 0 ]]; then
-            IFS=$'\n' packages_to_download=($(printf '%s\n' "${packages_to_download[@]}" | sort -u))
+            mapfile -t packages_to_download < <(printf '%s\n' "${packages_to_download[@]}" | sort -u)
             log "    Found ${#packages_to_download[@]} new dependencies to resolve"
         fi
     done

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -8,7 +8,8 @@
 # - DOWNLOAD_BATCH_SIZE: Size multiplier for download batches (default: 5, results in PARALLEL_DOWNLOADS * 5 per batch)
 # - LOOKUP_BATCH_SIZE: Size multiplier for lookup batches (default: 4, results in PARALLEL_DOWNLOADS * 4 per batch)
 # - RETRY_FAILED_DOWNLOADS: Enable retry of failed downloads (default: true)
-# - MAX_RETRY_COUNT: Maximum number of failed downloads to retry (default: 20)
+# - MAX_RETRY_ROUNDS: Maximum number of retry rounds for failed downloads (default: 3)
+# - RETRY_BACKOFF_SECONDS: Delay between retry rounds (default: 15)
 # - MIRROR_DIR: Directory for the mirror (default: /tmp/repository)
 # - SCRIPT_DIR: Directory containing config files
 
@@ -31,7 +32,8 @@ PARALLEL_DOWNLOADS="${PARALLEL_DOWNLOADS:-10}"
 DOWNLOAD_BATCH_SIZE="${DOWNLOAD_BATCH_SIZE:-5}"
 LOOKUP_BATCH_SIZE="${LOOKUP_BATCH_SIZE:-4}"
 RETRY_FAILED_DOWNLOADS="${RETRY_FAILED_DOWNLOADS:-true}"
-MAX_RETRY_COUNT="${MAX_RETRY_COUNT:-20}"
+MAX_RETRY_ROUNDS="${MAX_RETRY_ROUNDS:-3}"
+RETRY_BACKOFF_SECONDS="${RETRY_BACKOFF_SECONDS:-15}"
 
 # Performance optimizations
 PACKAGES_CACHE_DIR="$TEMP_DIR/packages_cache"
@@ -356,50 +358,72 @@ parallel_download_files() {
         fi
     done
 
-    # Retry failed downloads once with reduced concurrency for better reliability
-    if [[ "$RETRY_FAILED_DOWNLOADS" == "true" ]] && [[ ${#failed_urls[@]} -gt 0 ]] && [[ ${#failed_urls[@]} -le $MAX_RETRY_COUNT ]]; then
-        log "  Retrying ${#failed_urls[@]} failed downloads with reduced concurrency..."
-
-        local retry_temp_log="$TEMP_DIR/retry_download_log_$$.txt"
-        > "$retry_temp_log"
-
-        local retry_url_list="$TEMP_DIR/retry_url_list_$$.txt"
-        > "$retry_url_list"
-
-        for url in "${failed_urls[@]}"; do
-            local filename=$(basename "$url")
-            local output_path="$download_dir/$filename"
-            echo "$url|$output_path" >> "$retry_url_list"
-        done
-
+    # Retry failed downloads with reduced concurrency. The retry budget is a
+    # number of rounds, not a ceiling on how many failures are eligible: a
+    # mirror that fails many downloads at once is precisely the case that
+    # needs retrying, and giving up then leaves the repository incomplete.
+    if [[ "$RETRY_FAILED_DOWNLOADS" == "true" ]] && [[ ${#failed_urls[@]} -gt 0 ]]; then
         # Use reduced concurrency for retries (max 3 concurrent)
         local retry_concurrency=$((PARALLEL_DOWNLOADS > 3 ? 3 : PARALLEL_DOWNLOADS))
+        local retry_round=0
 
-        cat "$retry_url_list" | xargs -P "$retry_concurrency" -I {} bash -c '
-            IFS="|" read -r url output <<< "{}"
-            parallel_download_single "$url" "$output" "'$retry_temp_log'"
-        '
+        while [[ ${#failed_urls[@]} -gt 0 && $retry_round -lt $MAX_RETRY_ROUNDS ]]; do
+            retry_round=$((retry_round + 1))
 
-        # Process retry results
-        local retry_success=0
-        local retry_failed=0
+            log "  Retry round $retry_round/$MAX_RETRY_ROUNDS: ${#failed_urls[@]} downloads (concurrency $retry_concurrency)..."
 
-        while IFS= read -r line; do
-            if [[ "$line" == SUCCESS:* ]]; then
-                retry_success=$((retry_success + 1))
-                total_success=$((total_success + 1))
-                total_failed=$((total_failed - 1))
-            elif [[ "$line" == FAILED:* ]]; then
-                retry_failed=$((retry_failed + 1))
-                warning "      Retry $line"
+            local retry_temp_log="$TEMP_DIR/retry_download_log_${retry_round}_$$.txt"
+            > "$retry_temp_log"
+
+            local retry_url_list="$TEMP_DIR/retry_url_list_${retry_round}_$$.txt"
+            > "$retry_url_list"
+
+            # Map basename back to URL so a later round can retry whatever is
+            # still missing.
+            declare -A retry_url_by_name=()
+            for url in "${failed_urls[@]}"; do
+                local filename=$(basename "$url")
+                retry_url_by_name["$filename"]="$url"
+                echo "$url|$download_dir/$filename" >> "$retry_url_list"
+            done
+
+            xargs -a "$retry_url_list" -P "$retry_concurrency" -I {} bash -c '
+                IFS="|" read -r url output <<< "{}"
+                parallel_download_single "$url" "$output" "'"$retry_temp_log"'"
+            '
+
+            # Process retry results
+            local retry_success=0
+            local still_failed=()
+
+            while IFS= read -r line; do
+                if [[ "$line" == SUCCESS:* ]]; then
+                    retry_success=$((retry_success + 1))
+                    total_success=$((total_success + 1))
+                    total_failed=$((total_failed - 1))
+                elif [[ "$line" == FAILED:* ]]; then
+                    local failed_filename=${line#FAILED: }
+                    failed_filename=${failed_filename%% (*}
+                    if [[ -n "${retry_url_by_name[$failed_filename]:-}" ]]; then
+                        still_failed+=("${retry_url_by_name[$failed_filename]}")
+                    fi
+                    warning "      Retry $line"
+                fi
+            done < "$retry_temp_log"
+
+            log "    Retry round $retry_round: $retry_success recovered, ${#still_failed[@]} still failed"
+
+            rm -f "$retry_temp_log" "$retry_url_list"
+
+            failed_urls=("${still_failed[@]}")
+
+            # Back off before the next round to give a struggling mirror a
+            # chance to recover.
+            if [[ ${#failed_urls[@]} -gt 0 && $retry_round -lt $MAX_RETRY_ROUNDS ]]; then
+                log "    Waiting ${RETRY_BACKOFF_SECONDS}s before the next retry round..."
+                sleep "$RETRY_BACKOFF_SECONDS"
             fi
-        done < "$retry_temp_log"
-
-        log "    Retry results: $retry_success recovered, $retry_failed still failed"
-
-        rm -f "$retry_temp_log" "$retry_url_list"
-    elif [[ ${#failed_urls[@]} -gt $MAX_RETRY_COUNT ]]; then
-        log "    Too many failed downloads (${#failed_urls[@]}) - skipping retry to avoid overwhelming servers (max: $MAX_RETRY_COUNT)"
+        done
     fi
 
     log "  Total parallel download results: $total_success succeeded, $total_failed failed, $total_skipped skipped"
@@ -1415,7 +1439,7 @@ main() {
     log "  - Parallel downloads: $PARALLEL_DOWNLOADS concurrent connections"
     log "  - Download batch size: $((PARALLEL_DOWNLOADS * DOWNLOAD_BATCH_SIZE)) files per batch (${PARALLEL_DOWNLOADS} × ${DOWNLOAD_BATCH_SIZE})"
     log "  - Lookup batch size: $((PARALLEL_DOWNLOADS * LOOKUP_BATCH_SIZE)) packages per batch (${PARALLEL_DOWNLOADS} × ${LOOKUP_BATCH_SIZE})"
-    log "  - Retry failed downloads: $RETRY_FAILED_DOWNLOADS (max: $MAX_RETRY_COUNT)"
+    log "  - Retry failed downloads: $RETRY_FAILED_DOWNLOADS (rounds: $MAX_RETRY_ROUNDS, backoff: ${RETRY_BACKOFF_SECONDS}s)"
 
     check_dependencies
     read_config

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -670,33 +670,55 @@ cache_packages_file() {
     if [[ ! -f "$cache_file" ]]; then
         mkdir -p "$PACKAGES_CACHE_DIR"
 
+        # Stage the download and publish it into the cache only once it is
+        # complete and readable.
+        #
+        # wget and curl create the target file as soon as the transfer starts,
+        # so writing $cache_file directly makes a partial index visible to the
+        # other lookup workers: they see the file exists, skip the download,
+        # read a truncated package list, and report perfectly good packages as
+        # "not found in any repository". Measured on a 19 MB index, the file is
+        # present and incomplete for roughly the first half second, which is
+        # exactly when the first lookup batch runs against a cold cache.
+        #
+        # The staged names carry $$ so concurrent workers never share one, and
+        # mv is atomic within the directory, so a reader sees either no file or
+        # a complete one.
+        local staged="$cache_file.$$.part"
+
         # Try .gz first
-        if download_file "$packages_url" "$cache_file" >/dev/null 2>&1 && [[ -s "$cache_file" ]]; then
+        if download_file "$packages_url" "$staged" >/dev/null 2>&1 && [[ -s "$staged" ]] \
+                && gzip -t "$staged" 2>/dev/null; then
+            mv -f "$staged" "$cache_file"
             return 0
         fi
-        rm -f "$cache_file"
+        rm -f "$staged"
 
         # Try .xz and convert to .gz
         local xz_url="${packages_url%.gz}.xz"
-        local xz_file="${cache_file%.gz}.xz"
+        local xz_file="$cache_file.$$.xz"
         if download_file "$xz_url" "$xz_file" >/dev/null 2>&1 && [[ -s "$xz_file" ]]; then
-            if xzcat "$xz_file" 2>/dev/null | gzip > "$cache_file" 2>/dev/null && [[ -s "$cache_file" ]]; then
+            if xzcat "$xz_file" 2>/dev/null | gzip > "$staged" 2>/dev/null && [[ -s "$staged" ]]; then
                 rm -f "$xz_file"
+                mv -f "$staged" "$cache_file"
                 return 0
             fi
         fi
-        rm -f "$xz_file" "$cache_file"
+        rm -f "$xz_file" "$staged"
 
         # Try uncompressed and convert to .gz
         local plain_url="${packages_url%.gz}"
-        local plain_file="${cache_file%.gz}"
+        local plain_file="$cache_file.$$.plain"
         if download_file "$plain_url" "$plain_file" >/dev/null 2>&1 && [[ -s "$plain_file" ]]; then
-            if gzip -c "$plain_file" > "$cache_file" 2>/dev/null && [[ -s "$cache_file" ]]; then
+            if gzip -c "$plain_file" > "$staged" 2>/dev/null && [[ -s "$staged" ]]; then
                 rm -f "$plain_file"
+                mv -f "$staged" "$cache_file"
                 return 0
             fi
         fi
-        rm -f "$plain_file" "$cache_file"
+        # Never remove $cache_file here: another worker may have published a
+        # complete copy while this one was failing over between formats.
+        rm -f "$plain_file" "$staged"
         report_index_fetch_failure "$packages_url" "$cache_key"
         return 1
     fi

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -1424,9 +1424,23 @@ create_repository() {
         error "No .deb files found to copy"
     fi
 
-    # Generate Packages file
+    # Generate Packages file.
+    #
+    # Keep dpkg-scanpackages' diagnostics: its stderr is the only thing that
+    # names the offending file when it refuses to parse a package, and it
+    # exits 25 on every error, which on its own says nothing. Warnings about
+    # a missing override file are expected here and are filtered out so they
+    # do not look like failures.
     cd "$repo_dir"
-    dpkg-scanpackages --multiversion pool/main /dev/null > dists/stable/main/binary-amd64/Packages 2>/dev/null
+    local scan_errors="$TEMP_DIR/dpkg-scanpackages.err"
+    if ! dpkg-scanpackages --multiversion pool/main /dev/null \
+            > dists/stable/main/binary-amd64/Packages 2> "$scan_errors"; then
+        log "${RED}dpkg-scanpackages failed while indexing $repo_dir:${NC}"
+        grep -vE 'missing from override file|^dpkg-scanpackages: warning:   ' "$scan_errors" >&2 || true
+        error "Failed to generate the Packages index"
+    fi
+    grep -vE 'missing from override file|^dpkg-scanpackages: warning:   ' "$scan_errors" >&2 || true
+
     gzip -9c dists/stable/main/binary-amd64/Packages > dists/stable/main/binary-amd64/Packages.gz
 
     # Create Release file with proper checksums

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -508,6 +508,12 @@ parallel_download_files() {
 
     log "  Total parallel download results: $total_success succeeded, $total_failed failed, $total_skipped skipped"
 
+    # Record what is still missing after the retry rounds, so the run summary
+    # and the caller can report it.
+    if [[ ${#failed_urls[@]} -gt 0 ]]; then
+        FAILED_URLS+=("${failed_urls[@]}")
+    fi
+
     return $total_failed
 }
 

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -41,7 +41,6 @@ PACKAGES_CACHE_DIR="$TEMP_DIR/packages_cache"
 # "filename<TAB>sha256<TAB>size" records. Written while resolving package URLs
 # and consulted after each download.
 PACKAGES_CHECKSUM_FILE="$TEMP_DIR/expected_checksums.tsv"
-declare -A PACKAGES_METADATA_CACHE
 
 # Colors for output
 RED='\033[0;31m'
@@ -576,7 +575,6 @@ parallel_package_lookups() {
     # Export functions and variables needed by subprocesses
     export -f parallel_package_lookup find_best_package find_package_info find_all_package_versions find_latest_netbird_version version_compare download_file cache_packages_file build_packages_url record_package_checksum
     export TEMP_DIR PACKAGES_CACHE_DIR PACKAGES_CHECKSUM_FILE
-    export -A PACKAGES_METADATA_CACHE
 
     # Use xargs for package lookups (GNU parallel disabled due to argument parsing issues)
     cat "$package_list" | xargs -P "$PARALLEL_DOWNLOADS" -I {} bash -c "
@@ -687,14 +685,6 @@ find_package_info() {
         return 1
     fi
 
-    # Check metadata cache first (use safe key format)
-    local safe_package_name=$(echo "$package_name" | sed 's|[^a-zA-Z0-9]|_|g')
-    local cache_lookup_key="${cache_key}_${safe_package_name}"
-    if [[ -n "${PACKAGES_METADATA_CACHE[$cache_lookup_key]}" ]]; then
-        echo "${PACKAGES_METADATA_CACHE[$cache_lookup_key]}"
-        return 0
-    fi
-
     # Extract package info including version
     # Use sort -V | tail -1 to pick only the latest version when multiple exist
     # (e.g. flat repos like netdata may have multiple versions in one Packages file)
@@ -738,8 +728,6 @@ find_package_info() {
             "$(echo "$package_info" | cut -d'|' -f4)"
         local result="$version|$base_url/$filename"
 
-        # Cache the result
-        PACKAGES_METADATA_CACHE[$cache_lookup_key]="$result"
         echo "$result"
     fi
 }

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -614,8 +614,9 @@ parallel_package_lookups() {
                 else
                     log "    Already have: $deb_filename"
                     # Mark as downloaded since we already have it
-                    if [[ ! " ${downloaded_packages[@]} " =~ " ${package_name} " ]]; then
+                    if [[ -z "${downloaded_seen[$package_name]:-}" ]]; then
                         downloaded_packages+=("$package_name")
+                        downloaded_seen["$package_name"]=1
                     fi
                 fi
             fi
@@ -1096,6 +1097,12 @@ download_packages() {
     local failed_packages=()
     local packages_to_download=()
     local processed_packages=()
+    # Membership sets kept alongside the arrays above. Scanning
+    # " ${array[@]} " with =~ rebuilds the whole array into a string on every
+    # test, which is quadratic in the number of packages, and it treats the
+    # needle as a regular expression.
+    local -A processed_seen=()
+    local -A downloaded_seen=()
 
     # Initialize with user-requested packages
     packages_to_download=("${PACKAGES[@]}")
@@ -1164,11 +1171,12 @@ download_packages() {
 
         for package in "${packages_to_download[@]}"; do
             # Skip if already processed
-            if [[ " ${processed_packages[@]} " =~ " ${package} " ]]; then
+            if [[ -n "${processed_seen[$package]:-}" ]]; then
                 continue
             fi
 
             processed_packages+=("$package")
+            processed_seen["$package"]=1
             log "    Resolving dependencies for: $package"
 
             # Split the dependency list on spaces explicitly rather than
@@ -1181,7 +1189,7 @@ download_packages() {
             fi
 
             for dep in "${dep_names[@]}"; do
-                if [[ -n "$dep" && ! " ${processed_packages[@]} " =~ " ${dep} " ]]; then
+                if [[ -n "$dep" && -z "${processed_seen[$dep]:-}" ]]; then
                     new_dependencies+=("$dep")
                     log "      Found dependency: $dep"
                 fi
@@ -1191,7 +1199,7 @@ download_packages() {
         # Remove duplicates and update packages_to_download
         packages_to_download=()
         for dep in "${new_dependencies[@]}"; do
-            if [[ ! " ${processed_packages[@]} " =~ " ${dep} " ]]; then
+            if [[ -z "${processed_seen[$dep]:-}" ]]; then
                 packages_to_download+=("$dep")
             fi
         done
@@ -1218,7 +1226,7 @@ download_packages() {
                 packages_to_lookup+=("$package")
                 ;;
             *)
-                if [[ ! " ${downloaded_packages[@]} " =~ " ${package} " ]]; then
+                if [[ -z "${downloaded_seen[$package]:-}" ]]; then
                     packages_to_lookup+=("$package")
                 fi
                 ;;
@@ -1348,8 +1356,9 @@ download_packages() {
 
                 # Mark package as downloaded if any version was downloaded
                 if [[ "$package_downloaded" == true ]]; then
-                    if [[ ! " ${downloaded_packages[@]} " =~ " ${package} " ]]; then
+                    if [[ -z "${downloaded_seen[$package]:-}" ]]; then
                         downloaded_packages+=("$package")
+                        downloaded_seen["$package"]=1
                     fi
                 fi
             done
@@ -1362,7 +1371,7 @@ download_packages() {
 
     # Check for failed packages (only check originally requested packages)
     for package in "${PACKAGES[@]}"; do
-        if [[ ! " ${downloaded_packages[@]} " =~ " ${package} " ]]; then
+        if [[ -z "${downloaded_seen[$package]:-}" ]]; then
             failed_packages+=("$package")
         fi
     done

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -573,7 +573,7 @@ parallel_package_lookups() {
     printf '%s\n' "${packages[@]}" > "$package_list"
 
     # Export functions and variables needed by subprocesses
-    export -f parallel_package_lookup find_best_package find_package_info find_all_package_versions find_latest_netbird_version version_compare download_file cache_packages_file build_packages_url record_package_checksum
+    export -f parallel_package_lookup find_best_package find_package_info find_all_package_versions find_latest_netbird_version version_compare download_file cache_packages_file build_packages_url record_package_checksum report_index_fetch_failure
     export TEMP_DIR PACKAGES_CACHE_DIR PACKAGES_CHECKSUM_FILE
 
     # Use xargs for package lookups (GNU parallel disabled due to argument parsing issues)
@@ -629,6 +629,30 @@ parallel_package_lookups() {
     return 0
 }
 
+# Report an unreachable package index, once per index.
+#
+# Without this a repository that throttles or drops connections is entirely
+# silent: cache_packages_file() just returns non-zero, find_best_package()
+# finds no candidate, and every package that repository should have provided
+# is reported as "not found in any repository" -- which reads as "this package
+# does not exist" rather than "the mirror stopped answering".
+#
+# The message goes to stderr on purpose. This runs inside find_package_info(),
+# whose stdout is captured by its caller, so anything written to stdout here
+# would be parsed as a package URL.
+report_index_fetch_failure() {
+    local packages_url="$1"
+    local cache_key="$2"
+    local marker="$PACKAGES_CACHE_DIR/.fetch-failed-${cache_key}"
+
+    # Lookups run in parallel worker processes. mkdir is atomic, so exactly one
+    # worker reports each index instead of one message per package.
+    if mkdir "$marker" 2>/dev/null; then
+        echo "WARNING: could not fetch package index: $packages_url" >&2
+        echo "         packages provided only by this repository will be reported as not found" >&2
+    fi
+}
+
 # Download and cache Packages.gz file
 cache_packages_file() {
     local packages_url="$1"
@@ -665,6 +689,7 @@ cache_packages_file() {
             fi
         fi
         rm -f "$plain_file" "$cache_file"
+        report_index_fetch_failure "$packages_url" "$cache_key"
         return 1
     fi
     return 0

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -38,8 +38,8 @@ RETRY_BACKOFF_SECONDS="${RETRY_BACKOFF_SECONDS:-15}"
 # Performance optimizations
 PACKAGES_CACHE_DIR="$TEMP_DIR/packages_cache"
 # Expected checksums harvested from the repository indexes, as
-# "filename<TAB>sha256<TAB>size" records. Written while resolving package URLs
-# and consulted after each download.
+# "url<TAB>sha256<TAB>size" records. Written while resolving package URLs and
+# consulted after each download, matched on the URL the file came from.
 PACKAGES_CHECKSUM_FILE="$TEMP_DIR/expected_checksums.tsv"
 
 # Colors for output
@@ -153,16 +153,23 @@ download_file() {
 
 # Record the expected checksum of a package file, as advertised by the
 # repository index it was resolved from.
+#
+# Keyed by the full download URL rather than by basename. find_best_package()
+# asks every configured repository for a candidate and only then picks a
+# winner, so candidates that lose the version or priority comparison are
+# recorded too. Keying by basename would let a losing repository's checksum be
+# matched against the winner's download, which is correct only as long as any
+# two repositories sharing a filename also serve identical bytes.
 record_package_checksum() {
-    local filename="$1"
+    local url="$1"
     local sha256="$2"
     local size="$3"
 
-    if [[ -z "$filename" || -z "$sha256" || -z "${PACKAGES_CHECKSUM_FILE:-}" ]]; then
+    if [[ -z "$url" || -z "$sha256" || -z "${PACKAGES_CHECKSUM_FILE:-}" ]]; then
         return 0
     fi
 
-    printf '%s\t%s\t%s\n' "$filename" "$sha256" "$size" >> "$PACKAGES_CHECKSUM_FILE"
+    printf '%s\t%s\t%s\n' "$url" "$sha256" "$size" >> "$PACKAGES_CHECKSUM_FILE"
 }
 
 # Verify a downloaded file. Prefers the SHA256 and Size advertised by the
@@ -171,15 +178,16 @@ record_package_checksum() {
 # returns non-zero when the file must be discarded.
 verify_downloaded_file() {
     local path="$1"
+    local url="$2"
     local filename
     filename=$(basename "$path")
 
     local expected_sha256=""
     local expected_size=""
 
-    if [[ -n "${PACKAGES_CHECKSUM_FILE:-}" && -f "$PACKAGES_CHECKSUM_FILE" ]]; then
+    if [[ -n "$url" && -n "${PACKAGES_CHECKSUM_FILE:-}" && -f "$PACKAGES_CHECKSUM_FILE" ]]; then
         local record
-        record=$(awk -F'\t' -v f="$filename" '$1 == f { print; exit }' "$PACKAGES_CHECKSUM_FILE" 2>/dev/null)
+        record=$(awk -F'\t' -v u="$url" '$1 == u { print; exit }' "$PACKAGES_CHECKSUM_FILE" 2>/dev/null)
         if [[ -n "$record" ]]; then
             IFS=$'\t' read -r _ expected_sha256 expected_size <<< "$record"
         fi
@@ -292,7 +300,7 @@ parallel_download_single() {
             # example a chunked response truncated by the server), so the
             # content has to be checked, not just its presence.
             local verify_reason=""
-            if ! verify_reason=$(verify_downloaded_file "$output"); then
+            if ! verify_reason=$(verify_downloaded_file "$output" "$url"); then
                 echo "        - Failed (corrupt): $filename ($verify_reason)" >&2
                 echo "FAILED: $filename (corrupt: $verify_reason)" >> "$temp_log"
                 rm -f "$output"
@@ -748,7 +756,7 @@ find_package_info() {
     if [[ -n "$package_info" ]]; then
         local version=$(echo "$package_info" | cut -d'|' -f1)
         local filename=$(echo "$package_info" | cut -d'|' -f2)
-        record_package_checksum "$(basename "$filename")" \
+        record_package_checksum "$base_url/$filename" \
             "$(echo "$package_info" | cut -d'|' -f3)" \
             "$(echo "$package_info" | cut -d'|' -f4)"
         local result="$version|$base_url/$filename"
@@ -844,7 +852,7 @@ find_latest_netbird_version() {
                             if [[ -z "$latest_version" ]] || [[ $(version_compare "$version" "$latest_version") -eq 1 ]]; then
                                 latest_version="$version"
                                 latest_url="$base_url/$filename"
-                                record_package_checksum "$(basename "$filename")" \
+                                record_package_checksum "$latest_url" \
                                     "$(echo "$package_info" | cut -d'|' -f3)" \
                                     "$(echo "$package_info" | cut -d'|' -f4)"
                             fi
@@ -923,7 +931,7 @@ find_all_package_versions() {
                         if [[ -n "$package_info" ]]; then
                             local filename=$(echo "$package_info" | cut -d'|' -f2)
                             all_urls+=("$base_url/$filename")
-                            record_package_checksum "$(basename "$filename")" \
+                            record_package_checksum "$base_url/$filename" \
                                 "$(echo "$package_info" | cut -d'|' -f3)" \
                                 "$(echo "$package_info" | cut -d'|' -f4)"
                         fi

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -231,6 +231,11 @@ parallel_download_single() {
             result=1
         fi
     else
+        # wget/curl truncate the output file before transferring, so a failed
+        # transfer leaves a partial file behind. It is non-empty, so every
+        # later [[ -s ]] check accepts it and it ends up in the repository,
+        # where dpkg-scanpackages fails on it. Drop it here.
+        rm -f "$output"
         echo "        - Failed (download error): $filename" >&2
         echo "FAILED: $filename (download error)" >> "$temp_log"
         result=1

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -1515,7 +1515,28 @@ cleanup() {
     if [[ -d "$TEMP_DIR" ]]; then
         rm -rf "$TEMP_DIR"
     fi
-    success "Cleanup completed"
+    # Deliberately not success(): this reports on the cleanup step only, and
+    # on a failed run a "SUCCESS:" line here is the last thing in the log.
+    log "Cleanup completed"
+}
+
+# Exit handler. Runs cleanup, then states the outcome of the run as the final
+# line of the log, so that the tail of the log -- which is what a failure
+# report or a log excerpt shows -- says whether the run passed or failed
+# instead of ending on a cleanup message.
+on_exit() {
+    local exit_code=$?
+
+    cleanup
+
+    if [[ $exit_code -eq 0 ]]; then
+        success "Mirror creation finished successfully"
+    else
+        log "${RED}FAILED: mirror creation aborted with exit code $exit_code${NC}"
+        log "${RED}        the cause is on the ERROR line above${NC}"
+    fi
+
+    return $exit_code
 }
 
 # Build container image
@@ -1583,8 +1604,8 @@ main() {
     log "$(date): Script execution finished"
 }
 
-# Trap for cleanup on exit
-trap cleanup EXIT
+# Trap for cleanup and outcome reporting on exit
+trap on_exit EXIT
 
 # Run main function
 main "$@"

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -700,7 +700,7 @@ find_package_info() {
     # Filter by architecture to avoid downloading wrong arch (e.g. armhf instead of amd64)
     local package_info=$(zcat "$cache_file" 2>/dev/null | awk -v pkg="$package_name" -v arch="$target_arch" '
         BEGIN { RS="\n\n"; FS="\n" }
-        $1 ~ "^Package: " pkg "$" {
+        $1 == "Package: " pkg {
             filename = ""
             version = ""
             pkg_arch = ""
@@ -791,7 +791,7 @@ find_latest_netbird_version() {
                 # Extract all versions and find the latest
                 local package_infos=$(zcat "$packages_file" 2>/dev/null | awk -v pkg="$package_name" -v target_arch="$arch" '
                     BEGIN { RS="\n\n"; FS="\n" }
-                    $1 ~ "^Package: " pkg "$" {
+                    $1 == "Package: " pkg {
                         filename = ""
                         version = ""
                         pkg_arch = ""
@@ -875,7 +875,7 @@ find_all_package_versions() {
                 # Extract all versions of the package
                 local package_infos=$(zcat "$packages_file" 2>/dev/null | awk -v pkg="$package_name" -v target_arch="$arch" '
                     BEGIN { RS="\n\n"; FS="\n" }
-                    $1 ~ "^Package: " pkg "$" {
+                    $1 == "Package: " pkg {
                         filename = ""
                         version = ""
                         pkg_arch = ""
@@ -1065,7 +1065,7 @@ resolve_dependencies_from_file() {
 
     local deps=$(zcat "$packages_file" 2>/dev/null | awk -v pkg="$package" '
         BEGIN { RS="\n\n"; FS="\n" }
-        $1 ~ "^Package: " pkg "$" {
+        $1 == "Package: " pkg {
             for (i=1; i<=NF; i++) {
                 if ($i ~ /^(Pre-)?Depends: /) {
                     # Extract value after "Depends: " or "Pre-Depends: "

--- a/zuul/files/create-mirror.sh
+++ b/zuul/files/create-mirror.sh
@@ -994,103 +994,79 @@ find_best_package() {
     fi
 }
 
-# Preload all package metadata for fast dependency resolution
-preload_packages_metadata() {
-    local repo_configs=("$@")
-    declare -gA ALL_PACKAGES_DEPS
+# Build a package -> dependencies map from the downloaded repository indexes.
+#
+# One pass per index file. Dependency names are cleaned up inside awk (version
+# constraints, alternatives, multiarch qualifiers) so that resolving a package
+# afterwards is a plain associative-array lookup instead of another pass over
+# the indexes.
+#
+# The results are accumulated in ALL_PACKAGES_DEPS. A package present in more
+# than one index (a base package that also has an update, say) contributes the
+# union of its dependencies, which is what the previous per-file scan produced.
+build_dependency_map() {
+    local packages_files=("$@")
+    declare -gA ALL_PACKAGES_DEPS=()
 
-    log "Preloading package metadata for fast dependency resolution..."
+    log "Indexing dependencies from ${#packages_files[@]} package metadata files..."
 
-    for repo_config in "${repo_configs[@]}"; do
-        IFS=':' read -r host path dist components arch <<< "$repo_config"
-        local base_url="http://$host$path"
-
-        IFS=',' read -ra COMP_ARRAY <<< "$components"
-        for component in "${COMP_ARRAY[@]}"; do
-            local packages_url=$(build_packages_url "$base_url" "$dist" "$component" "$arch")
-            local cache_key=$(echo "$packages_url" | sed 's|[^a-zA-Z0-9]|_|g')
-
-            if cache_packages_file "$packages_url"; then
-                local cache_file="$PACKAGES_CACHE_DIR/${cache_key}.gz"
-
-                # Parse and cache all dependencies at once
-                # Filter by architecture to avoid caching deps from wrong arch packages
-                zcat "$cache_file" 2>/dev/null | awk -v target_arch="$arch" '
-                    BEGIN { RS="\n\n"; FS="\n" }
-                    {
-                        package = ""
-                        depends = ""
-                        pkg_arch = ""
-                        for (i=1; i<=NF; i++) {
-                            if ($i ~ /^Package: /) {
-                                package = substr($i, 10)
-                            }
-                            if ($i ~ /^(Pre-)?Depends: /) {
-                                # Extract value after "Depends: " or "Pre-Depends: "
-                                idx = index($i, ": ")
-                                val = substr($i, idx + 2)
-                                # Remove version constraints and alternatives
-                                gsub(/\([^)]*\)/, "", val)
-                                gsub(/\|[^,]*/, "", val)
-                                gsub(/[ \t]+/, " ", val)
-                                if (depends != "") {
-                                    depends = depends ", " val
-                                } else {
-                                    depends = val
-                                }
-                            }
-                            if ($i ~ /^Architecture: /) {
-                                pkg_arch = substr($i, 15)
-                            }
-                        }
-                        if (package != "" && depends != "" && (pkg_arch == target_arch || pkg_arch == "all")) {
-                            print package ":" depends
-                        }
-                    }
-                ' | while IFS=: read -r pkg deps; do
-                    local safe_pkg=$(echo "$pkg" | sed 's|[^a-zA-Z0-9._-]|_|g')
-                    ALL_PACKAGES_DEPS["$safe_pkg"]="$deps"
-                done
+    local packages_file
+    for packages_file in "${packages_files[@]}"; do
+        local pkg deps
+        # A pipe would run the loop in a subshell and discard the map, so read
+        # from a process substitution instead.
+        while IFS=$'\t' read -r pkg deps; do
+            if [[ -n "${ALL_PACKAGES_DEPS[$pkg]:-}" ]]; then
+                ALL_PACKAGES_DEPS["$pkg"]+=" $deps"
+            else
+                ALL_PACKAGES_DEPS["$pkg"]="$deps"
             fi
-        done
-    done
+        done < <(zcat "$packages_file" 2>/dev/null | awk '
+            BEGIN { RS="\n\n"; FS="\n" }
+            {
+                package = ""
+                depends = ""
+                for (i=1; i<=NF; i++) {
+                    if ($i ~ /^Package: /) {
+                        package = substr($i, 10)
+                    } else if ($i ~ /^(Pre-)?Depends: /) {
+                        # Extract value after "Depends: " or "Pre-Depends: "
+                        idx = index($i, ": ")
+                        val = substr($i, idx + 2)
+                        depends = (depends != "") ? depends ", " val : val
+                    }
+                }
+                if (package == "" || depends == "") next
 
-    log "Preloaded metadata for ${#ALL_PACKAGES_DEPS[@]} packages"
-}
+                # No architecture filter here. This map only discovers
+                # dependency *names*; which file gets downloaded for a name is
+                # decided later by find_package_info(), which does filter by
+                # architecture. Filtering here would drop the dependencies of
+                # any stanza that omits an Architecture field.
 
-# Resolve package dependencies from a specific packages file
-resolve_dependencies_from_file() {
-    local package="$1"
-    local packages_file="$2"
+                # Remove version constraints and alternatives
+                gsub(/\([^)]*\)/, "", depends)
+                gsub(/\|[^,]*/, "", depends)
 
-    local deps=$(zcat "$packages_file" 2>/dev/null | awk -v pkg="$package" '
-        BEGIN { RS="\n\n"; FS="\n" }
-        $1 == "Package: " pkg {
-            for (i=1; i<=NF; i++) {
-                if ($i ~ /^(Pre-)?Depends: /) {
-                    # Extract value after "Depends: " or "Pre-Depends: "
-                    idx = index($i, ": ")
-                    depends = substr($i, idx + 2)
-                    # Remove version constraints and alternatives
-                    gsub(/\([^)]*\)/, "", depends)
-                    gsub(/\|[^,]*/, "", depends)
-                    gsub(/[ \t]+/, " ", depends)
-                    print depends
+                out = ""
+                n = split(depends, parts, ",")
+                for (j = 1; j <= n; j++) {
+                    name = parts[j]
+                    gsub(/[ \t]/, "", name)
+                    # Multiarch qualifiers are dependency syntax, not part of
+                    # the package name.
+                    sub(/:(any|native)$/, "", name)
+                    if (name == "") continue
+                    out = (out == "") ? name : out " " name
+                }
+                if (out != "") {
+                    print package "\t" out
                 }
             }
-        }
-    ')
+        ')
+    done
 
-    if [[ -n "$deps" ]]; then
-        # Split dependencies and clean up. Multiarch qualifiers (perl:any,
-        # python3:any, foo:native) are part of the dependency syntax, not of
-        # the package name, and no Packages file has a stanza for the
-        # qualified form -- strip them or the dependency is reported as not
-        # found in any repository.
-        echo "$deps" | tr ',' '\n' \
-            | sed -e 's/^[ \t]*//;s/[ \t]*$//' -e 's/:\(any\|native\)$//' \
-            | grep -v '^$'
-    fi
+    log "  Indexed dependencies for ${#ALL_PACKAGES_DEPS[@]} packages"
 }
 
 # Download additional direct URLs
@@ -1123,9 +1099,6 @@ download_packages() {
 
     # Initialize with user-requested packages
     packages_to_download=("${PACKAGES[@]}")
-
-    # Skip preloading (too slow) - use on-demand resolution instead
-    # preload_packages_metadata "${REPOSITORIES[@]}"
 
     log "Resolving dependencies for ${#PACKAGES[@]} initial packages..."
 
@@ -1175,7 +1148,11 @@ download_packages() {
 
     log "Loaded ${#packages_files[@]} package metadata files for dependency resolution"
 
-    # Resolve dependencies iteratively using ALL package files
+    # Index every package's dependencies once, up front. Resolving a package
+    # is then a lookup rather than a scan of every metadata file.
+    build_dependency_map "${packages_files[@]}"
+
+    # Resolve dependencies iteratively using the indexed metadata
     local iteration=0
     local max_iterations=10
 
@@ -1194,16 +1171,19 @@ download_packages() {
             processed_packages+=("$package")
             log "    Resolving dependencies for: $package"
 
-            # Find dependencies in ALL package files from ALL repositories
-            for packages_file in "${packages_files[@]}"; do
-                local deps=$(resolve_dependencies_from_file "$package" "$packages_file")
-                if [[ -n "$deps" ]]; then
-                    while IFS= read -r dep; do
-                        if [[ -n "$dep" && ! " ${processed_packages[@]} " =~ " ${dep} " ]]; then
-                            new_dependencies+=("$dep")
-                            log "      Found dependency: $dep"
-                        fi
-                    done <<< "$deps"
+            # Split the dependency list on spaces explicitly rather than
+            # relying on the ambient IFS, which other code in this function
+            # changes; an inherited IFS would collapse the whole list into a
+            # single bogus package name.
+            local -a dep_names=()
+            if [[ -n "${ALL_PACKAGES_DEPS[$package]:-}" ]]; then
+                IFS=' ' read -r -a dep_names <<< "${ALL_PACKAGES_DEPS[$package]}"
+            fi
+
+            for dep in "${dep_names[@]}"; do
+                if [[ -n "$dep" && ! " ${processed_packages[@]} " =~ " ${dep} " ]]; then
+                    new_dependencies+=("$dep")
+                    log "      Found dependency: $dep"
                 fi
             done
         done


### PR DESCRIPTION
Part of:

- osism/metalbox#375

---

Sixteen defect fixes in `zuul/files/create-mirror.sh`, one concern per commit.
No behaviour policy changes — the run still builds and publishes whatever it
managed to download. Making it refuse to do that is #373, on top of this.

Found while investigating the 2026-08-01 `metalbox-mirror-debian-packages-publish`
failure (`rc=25` on the mirror script, 47m39s, 60 days clean before it). The
immediate cause was one transient upstream fault, but almost every defect below
is visible by reading the script and predates the incident.

### Silently wrong output

| Commit | Effect |
|---|---|
| match package names literally, not as regex | package names were interpolated into an awk regex (`$1 ~ "^Package: " pkg "$"`), so `c++` parsed as a quantifier. **`libstdc++6` has never been in the published mirror** — it appeared every run as `Failed packages: libstdc++6`, which reads like an upstream problem |
| publish cached indexes atomically | `cache_packages_file()` downloaded straight into the path it tests with `-f`, so concurrent lookup workers read a truncated index and reported good packages as not found. Measured 1–5 packages lost per cold-cache round |
| strip multiarch qualifiers from dependencies | `perl:any`, `python3:any` never resolved |

`libstdc++6` turned out to be harmless in practice: `apt` itself declares
`Depends: libstdc++6 (>= 13.1)`, so every noble host already has it before the
mirror is consulted. The latent case is a mirrored package needing a newer
version than the base image ships.

### The 2026-08-01 failure path

| Commit | Effect |
|---|---|
| drop partial files on download error | the empty-file branch of `parallel_download_single()` did `rm -f`; the download-error branch did not. `wget -O` truncates before transferring, so each failure left a short non-empty file that every later check (`[[ -f && -s ]]`) accepted |
| retry in rounds, not by failure count | `${#failed_urls[@]} -le $MAX_RETRY_COUNT` — more failures meant *less* retry. 48 failures exceeded the cap of 20, so retry was skipped entirely |
| verify downloads against index checksums | SHA256/Size harvested from the indexes |
| key expected checksums by URL, not basename | hardening; no collisions exist in the configured repos today |

### The run reported success regardless

| Commit | Effect |
|---|---|
| keep dpkg-scanpackages diagnostics | `2>/dev/null` discarded the only message naming the offending file. `rc=25` carries no information on its own — every `dpkg-scanpackages` error path exits 25 |
| populate the failed-download list | `FAILED_URLS` was declared and read by two reports but never assigned. Both reports were dead code |
| report direct-URL download failures | silent exit 1/2 mid-run |
| report unreachable package indexes | a dead mirror looked like missing packages |
| end the log with the run's outcome | the `EXIT` trap printed `SUCCESS: Cleanup completed` as the last line even on failure |

### Bash defects

| Commit | Effect |
|---|---|
| remove the ineffective metadata cache | `export -A` cannot export an associative array; the cache never hit |
| stop leaking IFS in dependency resolution | `IFS=$'\n' arr=(...)` is a persistent assignment, not a prefix |
| track package sets in associative arrays | seven O(n²) regex scans over flattened arrays |
| index dependencies once instead of per package | 99 GB of gunzip collapsed to one pass; 11–12 min → ~1 min |

### Verification

- every commit parses under `bash -n` individually
- shellcheck 80 → 53 findings, no new kinds (it had independently flagged the
  array-flattening, regex-quoting and subshell-locality classes)
- full old-vs-new run against `archive.ubuntu.com`: old 981 debs / 981 indexed,
  new 982 / 982, zero invalid either side, `libstdc++6` present only in the new one

Not yet exercised in CI — the check job runs on changes to this file, so this PR
is its first real run.

